### PR TITLE
[DM-25835] Add alert hook and call it on exception

### DIFF
--- a/src/mobu/config.py
+++ b/src/mobu/config.py
@@ -10,6 +10,14 @@ from dataclasses import dataclass
 class Configuration:
     """Configuration for mobu."""
 
+    alert_hook: str = os.getenv("ALERT_HOOK", "None")
+    """The slack webhook used for alerting exceptions to slack.
+
+    Set with the ``ALERT_HOOK`` environment variable.
+    This is an https URL which should be considered secret.
+    "None" may be provided in a secret to disable this feature.
+    """
+
     private_key_path: str = os.getenv(
         "PRIVATE_KEY_PATH", "/etc/keys/signing_key.pem"
     )


### PR DESCRIPTION
Add an alert method which will call the ALERT_HOOK URL and post the
exception message to it along with the username that caused it and
the timestamp of the error.