### PR TITLE
[DM-28993] Update Python version and dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,20 +6,26 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python:
+          - 3.8
+          - 3.9
+
     steps:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: ${{ matrix.python }}
 
       - name: Install tox
         run: pip install tox
 
       - name: Cache tox environments
         id: cache-tox
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: .tox
           # requirements/*.txt, pyproject.toml, and .pre-commit-config.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = 'setuptools.build_meta'
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py37,coverage-report,typing,lint
+envlist = py,coverage-report,typing,lint
 isolated_build = True
 
 [testenv]
@@ -28,7 +28,7 @@ description = Compile coverage from each test run.
 skip_install = true
 deps = coverage[toml]>=5.0.2
 depends =
-    py37
+    py
 commands =
     coverage combine
     coverage report
@@ -75,7 +75,7 @@ exclude_lines = [
 
 [tool.black]
 line-length = 79
-target-version = ['py37']
+target-version = ['py38']
 exclude = '''
 /(
     \.eggs

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -145,9 +145,9 @@ flake8==3.8.4 \
     --hash=sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839 \
     --hash=sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b
     # via -r requirements/dev.in
-identify==2.0.0 \
-    --hash=sha256:9cdd81e5d2b6e76c3006d5226316dd947bd6324fbeebb881bec489202fa09d3a \
-    --hash=sha256:b99aa309329c4fea679463eb35d169f3fbe13e66e9dd6162ad1856cbeb03dcbd
+identify==2.1.0 \
+    --hash=sha256:2179e7359471ab55729f201b3fdf7dc2778e221f868410fedcb0987b791ba552 \
+    --hash=sha256:2a5fdf2f5319cc357eda2550bea713a404392495961022cf2462624ce62f0f46
     # via pre-commit
 idna==2.10 \
     --hash=sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6 \

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -13,7 +13,6 @@ cchardet
 click
 cryptography
 gitpython
-importlib_metadata
 jinja2
 pyjwt
 pyvo

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -193,10 +193,6 @@ idna==2.10 \
     # via
     #   requests
     #   yarl
-importlib-metadata==3.7.0 \
-    --hash=sha256:24499ffde1b80be08284100393955842be4a59c7c16bbf2738aad0e464a8e0aa \
-    --hash=sha256:c6af5dbf1126cd959c4a8d8efd61d4d3c83bddb0459a17e554284a077574b614
-    # via -r requirements/main.in
 jinja2==2.11.3 \
     --hash=sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419 \
     --hash=sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6
@@ -464,7 +460,3 @@ yarl==1.6.3 \
     --hash=sha256:f0b059678fd549c66b89bed03efcabb009075bd131c248ecdf087bdb6faba24a \
     --hash=sha256:fcbb48a93e8699eae920f8d92f7160c03567b421bc17362a9ffbbd706a816f71
     # via aiohttp
-zipp==3.4.0 \
-    --hash=sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108 \
-    --hash=sha256:ed5eee1974372595f9e416cc7bbeeb12335201d8081ca8a0743c954d4446e5cb
-    # via importlib-metadata

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Natural Language :: English
     Operating System :: POSIX
 keywords =
@@ -27,7 +27,7 @@ include_package_data = True
 package_dir =
     = src
 packages=find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires =
     setuptools_scm
 # Use requirements/main.in for runtime dependencies instead of install_requires

--- a/src/mobu/__init__.py
+++ b/src/mobu/__init__.py
@@ -2,13 +2,7 @@
 
 __all__ = ["__version__", "metadata"]
 
-import sys
-
-if sys.version_info < (3, 8):
-    from importlib_metadata import PackageNotFoundError, version
-else:
-    from importlib.metadata import PackageNotFoundError, version
-
+from importlib.metadata import PackageNotFoundError, version
 
 __version__: str
 """The application version string of (PEP 440 / SemVer compatible)."""


### PR DESCRIPTION
- Add dependabot configuration
- Require Python 3.8 or later and drop compatibility with Python 3.7
- Use a matrix for Python versions in CI and test 3.8 and 3.9
- Update versions of GitHub Actions dependencies
- Regenerate and update dependencies