### PR TITLE
[DM-29321] Bail out on bad progress URL status codes

### DIFF
--- a/src/mobu/jupyterclient.py
+++ b/src/mobu/jupyterclient.py
@@ -130,6 +130,9 @@ class JupyterClient:
                     self.log.info(f"Lab spawned, redirected to {r.url}")
                     return
 
+                if not r.ok:
+                    raise Exception(f"{progress_url} returned {r.status}")
+
                 self.log.info(f"Still waiting for lab to spawn {r}")
                 retries -= 1
                 await asyncio.sleep(poll_interval)


### PR DESCRIPTION
Before I would wait since it seemed like we would get a bunch of 200
status codes.  But if the first status code is a 500, apparently we
swallow it and keep waiting.  The next request gets a 200, even though
it isn't waiting at all for progress.  This is why it takes a whole
timeout of running through that loop, but really we should signal the
first error we see.  This won't fix anything, I don't think, but it
should reduce some noise and change some timings.