### PR TITLE
[DM-29321] Switch kernel name

### DIFF
--- a/src/mobu/jupyterclient.py
+++ b/src/mobu/jupyterclient.py
@@ -151,7 +151,7 @@ class JupyterClient:
             if r.status not in [200, 202, 204]:
                 raise Exception(f"Error {r.status} from {r.url}")
 
-    async def create_kernel(self, kernel_name: str = "python") -> str:
+    async def create_kernel(self, kernel_name: str = "LSST") -> str:
         kernel_url = (
             self.jupyter_url + f"user/{self.user.username}/api/kernels"
         )


### PR DESCRIPTION
Maybe the kernel thing broken when we got rid of system python
kernel?  I don't see it in the list anymore.