### PR TITLE
[DM-28120] Support Gafaelfawr 2.0

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -11,7 +11,9 @@ flake8
 mypy
 pytest
 pytest-aiohttp
+pytest-asyncio
 aiohttp-devtools
+aioresponses
 
 # Temporary to avoid a conflict with requirements/main.txt due to the pyvo
 # dependency on idna (by way of requests), which is capped at 2.10.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -48,7 +48,12 @@ aiohttp==3.7.4.post0 \
     --hash=sha256:fe60131d21b31fd1a14bd43e6bb88256f69dfc3188b3a89d736d6c71ed43ec95
     # via
     #   aiohttp-devtools
+    #   aioresponses
     #   pytest-aiohttp
+aioresponses==0.7.2 \
+    --hash=sha256:2f8ff624543066eb465b0238de68d29231e8488f41dc4b5a9dae190982cdae50 \
+    --hash=sha256:82e495d118b74896aa5b4d47e17effb5e2cc783e510ae395ceade5e87cabe89a
+    # via -r requirements/dev.in
 appdirs==1.4.4 \
     --hash=sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41 \
     --hash=sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128
@@ -272,12 +277,17 @@ pytest-aiohttp==0.3.0 \
     --hash=sha256:0b9b660b146a65e1313e2083d0d2e1f63047797354af9a28d6b7c9f0726fa33d \
     --hash=sha256:c929854339637977375838703b62fef63528598bc0a9d451639eba95f4aaa44f
     # via -r requirements/dev.in
+pytest-asyncio==0.14.0 \
+    --hash=sha256:2eae1e34f6c68fc0a9dc12d4bea190483843ff4708d24277c41568d6b6044f1d \
+    --hash=sha256:9882c0c6b24429449f5f969a5158b528f39bde47dc32e85b9f0403965017e700
+    # via -r requirements/dev.in
 pytest==6.2.3 \
     --hash=sha256:671238a46e4df0f3498d1c3270e5deb9b32d25134c99b7d75370a68cfbe9b634 \
     --hash=sha256:6ad9c7bdf517a808242b998ac20063c41532a570d088d77eec1ee12b0b5574bc
     # via
     #   -r requirements/dev.in
     #   pytest-aiohttp
+    #   pytest-asyncio
 pyyaml==5.4.1 \
     --hash=sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf \
     --hash=sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -146,9 +146,9 @@ filelock==3.0.12 \
     --hash=sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59 \
     --hash=sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836
     # via virtualenv
-flake8==3.9.0 \
-    --hash=sha256:12d05ab02614b6aee8df7c36b97d1a3b2372761222b19b58621355e82acddcff \
-    --hash=sha256:78873e372b12b093da7b5e5ed302e8ad9e988b38b063b61ad937f26ca58fc5f0
+flake8==3.9.1 \
+    --hash=sha256:1aa8990be1e689d96c745c5682b687ea49f2e05a443aff1f8251092b0014e378 \
+    --hash=sha256:3b9f848952dddccf635be78098ca75010f073bfe14d2c6bda867154bea728d2a
     # via -r requirements/dev.in
 identify==2.2.3 \
     --hash=sha256:398cb92a7599da0b433c65301a1b62b9b1f4bb8248719b84736af6c0b22289d6 \
@@ -249,9 +249,9 @@ pluggy==0.13.1 \
     --hash=sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0 \
     --hash=sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d
     # via pytest
-pre-commit==2.12.0 \
-    --hash=sha256:029d53cb83c241fe7d66eeee1e24db426f42c858f15a38d20bcefd8d8e05c9da \
-    --hash=sha256:46b6ffbab37986c47d0a35e40906ae029376deed89a0eb2e446fb6e67b220427
+pre-commit==2.12.1 \
+    --hash=sha256:70c5ec1f30406250b706eda35e868b87e3e4ba099af8787e3e8b4b01e84f4712 \
+    --hash=sha256:900d3c7e1bf4cf0374bb2893c24c23304952181405b4d88c9c40b72bda1bb8a9
     # via -r requirements/dev.in
 py==1.10.0 \
     --hash=sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3 \

--- a/src/mobu/config.py
+++ b/src/mobu/config.py
@@ -4,6 +4,7 @@ __all__ = ["Configuration"]
 
 import os
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -35,6 +36,15 @@ class Configuration:
     well as fields in the JWT ticket.
 
     Set with the ``ENVIRONMENT_URL`` environment variable.
+    """
+
+    gafaelfawr_token: Optional[str] = os.getenv("GAFAELFAWR_TOKEN", None)
+    """The Gafaelfawr admin token to use to create user tokens.
+
+    If set, this token is used to make an admin API call to Gafaelfawr to get
+    a token for the user.
+
+    Set with the ``GAFAELFAWR_TOKEN`` environment variable.
     """
 
     name: str = os.getenv("SAFIR_NAME", "mobu")

--- a/src/mobu/handlers/external/user.py
+++ b/src/mobu/handlers/external/user.py
@@ -29,7 +29,7 @@ async def post_user(request: web.Request) -> web.Response:
         body = await request.json()
         logger.info(body)
         manager = request.config_dict["mobu/monkeybusinessmanager"]
-        monkey = MonkeyBusinessFactory.create(body)
+        monkey = await MonkeyBusinessFactory.create(body)
         await manager.manage_monkey(monkey)
         data = {"user": monkey.user.username}
         return web.json_response(data)

--- a/src/mobu/monkeybusinessfactory.py
+++ b/src/mobu/monkeybusinessfactory.py
@@ -17,7 +17,7 @@ from mobu.user import User
 
 class MonkeyBusinessFactory:
     @staticmethod
-    def create(body: Dict) -> Monkey:
+    async def create(body: Dict) -> Monkey:
         name = body["name"]
         business = body["business"]
         user = body["user"]
@@ -26,7 +26,7 @@ class MonkeyBusinessFactory:
         username = user["username"]
         uidnumber = user["uidnumber"]
 
-        u = User(username, uidnumber)
+        u = await User.create(username, uidnumber)
         m = Monkey(name, u, options)
 
         businesses = [

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -1,0 +1,60 @@
+"""Tests for the User class."""
+
+from __future__ import annotations
+
+import base64
+import os
+import time
+from typing import TYPE_CHECKING
+from unittest.mock import ANY
+
+import pytest
+from aioresponses import CallbackResult, aioresponses
+
+from mobu.config import Configuration
+from mobu.user import User
+
+if TYPE_CHECKING:
+    from typing import Any, Callable
+
+
+def make_gafaelfawr_token() -> str:
+    key = base64.urlsafe_b64encode(os.urandom(16)).decode().rstrip("=")
+    secret = base64.urlsafe_b64encode(os.urandom(16)).decode().rstrip("=")
+    return f"gt-{key}.{secret}"
+
+
+def build_handler(admin_token: str) -> Callable[..., CallbackResult]:
+    def handler(url: str, **kwargs: Any) -> CallbackResult:
+        assert kwargs["headers"] == {"Authorization": f"bearer {admin_token}"}
+        assert kwargs["json"] == {
+            "username": "someuser",
+            "token_type": "user",
+            "token_name": ANY,
+            "scopes": ["exec:notebook"],
+            "expires": ANY,
+            "uid": 1234,
+        }
+        assert kwargs["json"]["token_name"].startswith("mobu ")
+        assert kwargs["json"]["expires"] > time.time()
+        response = {"token": make_gafaelfawr_token()}
+        return CallbackResult(payload=response, status=200)
+
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_generate_token() -> None:
+    admin_token = make_gafaelfawr_token()
+    handler = build_handler(admin_token)
+
+    Configuration.gafaelfawr_token = admin_token
+    with aioresponses() as m:
+        m.post(
+            "https://nublado.lsst.codes/auth/api/v1/tokens", callback=handler
+        )
+        user = await User.create("someuser", 1234)
+        assert user.username == "someuser"
+        assert user.uidnumber == 1234
+        assert user.token.startswith("gt-")
+    Configuration.gafaelfawr_token = None


### PR DESCRIPTION
Allow a Gafaelfawr admin token to be passed in via an environment
variable as configuration.  If that is set, get a user token for
the target user via a Gafaelfawr admin API call.  If not, fall back
on the old JWT construction logic.