### PR TITLE
[DM-29799] Fix robo-simon startup timing issue

### DIFF
--- a/src/mobu/notebookrunner.py
+++ b/src/mobu/notebookrunner.py
@@ -60,12 +60,10 @@ class NotebookRunner(Business):
             logger.info("Repository cloned and ready")
 
             await self._client.hub_login()
+            await self._client.delete_lab()
 
             while True:
                 self._next_notebook()
-
-                if self.success_count % 100 == 0:
-                    await self._client.delete_lab()
 
                 await self._client.ensure_lab()
 


### PR DESCRIPTION
Okay, so after a lot of investigation, I think the issue is a timing issue.  We were slower and I think waited longer on the deletes for nublado1 than nublado2.  Either way, we were able to delete the lab and recreate it after checking against the success count, and I think this quick re-making of the lab caused the issue.  While we weren't ready or after the lab had been deleted, we tried to make requests to make a kernel, which the code shouldn't have allowed, but perhaps there is a state during cleanup where the URL isn't a 404 yet, but isn't valid either.

Either way, I'm deleting the lab at the beginning of each cycle, right after the hub.  I've also gotten really explicit about the URL flow, which makes it a little more brittle, but also a little more clear what is happening.  This will also pull the alerts closer in time to the failure, to allow for better investigation.