### PR TITLE
[DM-31083] Use PUT instead of POST for creating flocks

### DIFF
--- a/src/mobu/handlers/external.py
+++ b/src/mobu/handlers/external.py
@@ -30,7 +30,7 @@ __all__ = [
     "get_monkey",
     "get_monkeys",
     "get_monkey_log",
-    "post_flock",
+    "put_flock",
 ]
 
 external_router = APIRouter()
@@ -86,7 +86,7 @@ async def get_flocks(
     return manager.list_flocks()
 
 
-@external_router.post(
+@external_router.put(
     "/flocks",
     response_class=FormattedJSONResponse,
     response_model=FlockData,
@@ -95,7 +95,7 @@ async def get_flocks(
     status_code=201,
     summary="Create a new flock",
 )
-async def post_flock(
+async def put_flock(
     flock_config: FlockConfig,
     response: Response,
     manager: MonkeyBusinessManager = Depends(monkey_business_manager),

--- a/src/monkeyflocker/client.py
+++ b/src/monkeyflocker/client.py
@@ -69,7 +69,7 @@ class MonkeyflockerClient:
             spec = yaml.safe_load(f)
         self._logger.info("Starting flock %s", spec["name"])
         url = urljoin(self._base_url, "/mobu/flocks")
-        await self._session.post(url, json=spec)
+        await self._session.put(url, json=spec)
         self._logger.info("Flock %s started", spec["name"])
 
     async def report(self, name: str, output: Path) -> None:

--- a/tests/business/jupyterloginloop_test.py
+++ b/tests/business/jupyterloginloop_test.py
@@ -21,7 +21,7 @@ async def test_run(
 ) -> None:
     mock_gafaelfawr(mock_aioresponses)
 
-    r = await client.post(
+    r = await client.put(
         "/mobu/flocks",
         json={
             "name": "test",

--- a/tests/business/jupyterpythonloop_test.py
+++ b/tests/business/jupyterpythonloop_test.py
@@ -21,7 +21,7 @@ async def test_run(
 ) -> None:
     mock_gafaelfawr(mock_aioresponses)
 
-    r = await client.post(
+    r = await client.put(
         "/mobu/flocks",
         json={
             "name": "test",

--- a/tests/handlers/flock_test.py
+++ b/tests/handlers/flock_test.py
@@ -29,7 +29,7 @@ async def test_start_stop(
         "scopes": ["exec:notebook"],
         "business": "Business",
     }
-    r = await client.post("/mobu/flocks", json=config)
+    r = await client.put("/mobu/flocks", json=config)
     assert r.status_code == 201
     expected: Dict[str, Any] = {
         "name": "test",
@@ -136,7 +136,7 @@ async def test_user_list(
         "scopes": ["exec:notebook"],
         "business": "Business",
     }
-    r = await client.post("/mobu/flocks", json=config)
+    r = await client.put("/mobu/flocks", json=config)
     assert r.status_code == 201
     expected: Dict[str, Any] = {
         "name": "test",
@@ -200,7 +200,7 @@ async def test_errors(
     mock_gafaelfawr(mock_aioresponses)
 
     # Both users and user_spec given.
-    r = await client.post(
+    r = await client.put(
         "/mobu/flocks",
         json={
             "name": "test",
@@ -232,7 +232,7 @@ async def test_errors(
     }
 
     # Neither users nor user_spec given.
-    r = await client.post(
+    r = await client.put(
         "/mobu/flocks",
         json={
             "name": "test",
@@ -253,7 +253,7 @@ async def test_errors(
     }
 
     # Too many users for the size of the flock.
-    r = await client.post(
+    r = await client.put(
         "/mobu/flocks",
         json={
             "name": "test",
@@ -293,7 +293,7 @@ async def test_errors(
     }
 
     # Not enough users for the size of the flock.
-    r = await client.post(
+    r = await client.put(
         "/mobu/flocks",
         json={
             "name": "test",
@@ -325,7 +325,7 @@ async def test_errors(
     }
 
     # Unknown business.
-    r = await client.post(
+    r = await client.put(
         "/mobu/flocks",
         json={
             "name": "test",


### PR DESCRIPTION
The client uploads a complete configuration, not a partial one
that's modified, so PUT seems like a more appropriate verb.