### PR TITLE
[DM-31201] Clean shutdown and other fixes

### DIFF
--- a/src/mobu/business/base.py
+++ b/src/mobu/business/base.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from asyncio import Queue, QueueEmpty, TimeoutError
+from enum import Enum
 from typing import TYPE_CHECKING
 
 from ..models.business import BusinessData
@@ -17,8 +19,28 @@ if TYPE_CHECKING:
 __all__ = ["Business"]
 
 
+class BusinessCommand(Enum):
+    """Commands sent over the internal control queue."""
+
+    STOP = "STOP"
+
+
 class Business:
     """Base class for monkey business (one type of repeated operation).
+
+    The basic flow for a monkey business is as follows:
+
+    - Run ``startup``
+    - In a loop, run ``execute`` followed by ``idle`` until told to stop
+    - When told to stop, run ``shutdown``
+
+    Subclasses should override ``startup``, ``execute``, and ``shutdown`` to
+    add appropriate behavior.  ``idle`` by default waits for ``idle_time``,
+    which generally does not need to be overridden.
+
+    All delays should be done by calling ``pause``, and the caller should
+    check ``self.stopping`` and exit any loops if it is `True` after calling
+    ``pause``.
 
     Parameters
     ----------
@@ -42,16 +64,68 @@ class Business:
         self.success_count = 0
         self.failure_count = 0
         self.timings = Timings()
+        self.control: Queue[BusinessCommand] = Queue()
+        self.stopping = False
 
     async def run(self) -> None:
-        while True:
-            self.logger.info("Idling...")
-            with self.timings.start("idle"):
-                await asyncio.sleep(5)
-            self.success_count += 1
+        """The core business logic, run in a background task."""
+        self.logger.info("Starting up...")
+        await self.startup()
+
+        while not self.stopping:
+            self.logger.info("Starting next iteration")
+            try:
+                await self.execute()
+                self.success_count += 1
+            except Exception:
+                self.failure_count += 1
+                raise
+            await self.idle()
+
+        self.logger.info("Shutting down...")
+        await self.shutdown()
+
+        # Tell the control channel we've processed the stop command.
+        self.control.task_done()
+
+    async def startup(self) -> None:
+        """Run before the start of the first iteration and then not again."""
+        pass
+
+    async def execute(self) -> None:
+        """The business done in each loop."""
+        pass
+
+    async def idle(self) -> None:
+        """The idle pause at the end of each loop."""
+        self.logger.info("Idling...")
+        with self.timings.start("idle"):
+            await self.pause(self.config.idle_time)
+
+    async def shutdown(self) -> None:
+        """Any cleanup to do before exiting after stopping."""
+        pass
 
     async def stop(self) -> None:
-        pass
+        """Tell the running background task to stop and wait for that."""
+        await self.control.put(BusinessCommand.STOP)
+        await self.control.join()
+        self.logger.info("Stopped")
+
+    async def pause(self, seconds: float) -> None:
+        """Pause for up to the number of seconds, handling commands."""
+        if self.stopping:
+            return
+        try:
+            if seconds:
+                command = await asyncio.wait_for(self.control.get(), seconds)
+            else:
+                command = self.control.get_nowait()
+        except (TimeoutError, QueueEmpty):
+            return
+        else:
+            if command == BusinessCommand.STOP:
+                self.stopping = True
 
     def dump(self) -> BusinessData:
         return BusinessData(

--- a/src/mobu/business/jupyterjitterloginloop.py
+++ b/src/mobu/business/jupyterjitterloginloop.py
@@ -7,7 +7,6 @@ instances.
 
 from __future__ import annotations
 
-import asyncio
 import random
 
 from .jupyterloginloop import JupyterLoginLoop
@@ -20,14 +19,17 @@ class JupyterJitterLoginLoop(JupyterLoginLoop):
 
     async def startup(self) -> None:
         with self.timings.start("pre_login_delay"):
-            await asyncio.sleep(random.uniform(0, 30))
+            await self.pause(random.uniform(0, 30))
+        if self.stopping:
+            return
         await super().startup()
-        await asyncio.sleep(random.uniform(10, 30))
+        await self.pause(random.uniform(10, 30))
 
     async def lab_business(self) -> None:
         with self.timings.start("lab_wait"):
-            await asyncio.sleep(1200 + random.uniform(0, 600))
+            await self.pause(1200 + random.uniform(0, 600))
 
     async def idle(self) -> None:
+        self.logger.info("Idling...")
         with self.timings.start("idle"):
-            await asyncio.sleep(30 + random.uniform(0, 60))
+            await self.pause(30 + random.uniform(0, 60))

--- a/src/mobu/business/jupyterloginloop.py
+++ b/src/mobu/business/jupyterloginloop.py
@@ -46,6 +46,9 @@ class JupyterLoginLoop(Business):
         super().__init__(logger, business_config, user)
         self._client = JupyterClient(user, logger, business_config)
 
+    async def close(self) -> None:
+        await self._client.close()
+
     async def startup(self) -> None:
         await self.hub_login()
         await self.initial_delete_lab()
@@ -63,7 +66,6 @@ class JupyterLoginLoop(Business):
 
     async def shutdown(self) -> None:
         await self.delete_lab()
-        await self._client.close()
 
     async def hub_login(self) -> None:
         self.logger.info("Logging in to hub")

--- a/src/mobu/business/jupyterloginloop.py
+++ b/src/mobu/business/jupyterloginloop.py
@@ -6,7 +6,6 @@ instance, and then delete them.
 
 from __future__ import annotations
 
-import asyncio
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
@@ -25,6 +24,15 @@ __all__ = ["JupyterLoginLoop"]
 class JupyterLoginLoop(Business):
     """Business that logs on to the hub, creates a lab, and deletes it.
 
+    This class modifies the core `~mobu.business.base.Business` loop by
+    providing the overall ``execute`` framework and defualt ``startup`` and
+    ``shutdown`` methods.  It will log on to JupyterHub, ensure no lab
+    currently exists, create a lab, run ``lab_business``, and then shut down
+    the lab before starting another iteration.
+
+    Subclasses should override ``lab_business`` to do whatever they want to do
+    inside a lab.  The default behavior just waits for ``login_idle_time``.
+
     Once this business has been stopped, it cannot be started again (the
     `aiohttp.ClientSession` will be closed), and the instance should be
     dropped after retrieving any status information.
@@ -40,85 +48,64 @@ class JupyterLoginLoop(Business):
         self._client = JupyterClient(user, logger, business_config)
         self._last_login = datetime.fromtimestamp(0, tz=timezone.utc)
 
-    async def run(self) -> None:
-        self.logger.info("Starting up...")
-        await self.startup()
-        while True:
-            await self.reauth_if_needed()
-            self.logger.info("Starting next iteration")
-            try:
-                await self.ensure_lab()
-                await self.lab_business()
-                await self.delete_lab()
-                self.success_count += 1
-            except Exception:
-                self.failure_count += 1
-                raise
-            await self.lab_idle()
-
     async def startup(self) -> None:
-        """Run before the start of the first iteration and then not again."""
         await self.hub_login()
+        await self.initial_delete_lab()
+
+    async def execute(self) -> None:
+        """The work done in each iteration of the loop."""
+        await self.reauth_if_needed()
+        await self.ensure_lab()
+        await self.lab_settle()
+        if self.stopping:
+            return
+        await self.lab_business()
+        if self.config.delete_lab:
+            await self.delete_lab()
+
+    async def shutdown(self) -> None:
+        await self.delete_lab()
+        await self._client.close()
 
     async def hub_login(self) -> None:
+        self.logger.info("Logging in to hub")
         with self.timings.start("hub_login"):
             await self._client.hub_login()
-            self._last_login = self._now()
+            self._last_login = datetime.now(tz=timezone.utc)
 
     async def ensure_lab(self) -> None:
         with self.timings.start("ensure_lab"):
             await self._client.ensure_lab()
-        self.logger.info("Lab created.")
+        self.logger.info("Lab created")
+
+    async def lab_settle(self) -> None:
+        with self.timings.start("lab_settle"):
+            await self.pause(self.config.settle_time)
 
     async def delete_lab(self) -> None:
-        self.logger.info("Deleting lab.")
+        self.logger.info("Deleting lab")
         with self.timings.start("delete_lab"):
             await self._client.delete_lab()
-        self.logger.info("Lab successfully deleted.")
+        self.logger.info("Lab successfully deleted")
+
+    async def initial_delete_lab(self) -> None:
+        self.logger.info("Deleting any existing lab")
+        with self.timings.start("initial_delete_lab"):
+            await self._client.delete_lab()
 
     async def lab_business(self) -> None:
         """Do whatever business we want to do inside a lab.
 
-        Placeholder function intended to be overridden by subclasses.
+        Placeholder function intended to be overridden by subclasses.  The
+        default behavior is to wait a minute and then shut the lab down
+        again.
         """
         with self.timings.start("lab_wait"):
-            await asyncio.sleep(5)
-
-    async def lab_idle(self) -> None:
-        """Executed at the end of each iteration for a given lab.
-
-        Intended to be overridden by subclasses if they want different idle
-        behavior.
-        """
-        delay = self.config.lab_idle_time
-        if delay > 0:
-            with self.timings.start("idle"):
-                await asyncio.sleep(delay)
-
-    async def execution_idle(self) -> None:
-        """Executed between each unit of work execution (usually a Lab
-        cell).
-        """
-        delay = self.config.execution_idle_time
-        if delay > 0:
-            with self.timings.start("execution_idle"):
-                await asyncio.sleep(self.config.execution_idle_time)
-
-    def _now(self) -> datetime:
-        return datetime.now(timezone.utc)
+            await self.pause(self.config.login_idle_time)
 
     async def reauth_if_needed(self) -> None:
-        now = self._now()
-        elapsed = now - self._last_login
+        elapsed = datetime.now(tz=timezone.utc) - self._last_login
         if elapsed > timedelta(self.config.reauth_interval):
-            await self.hub_reauth()
-
-    async def hub_reauth(self) -> None:
-        self.logger.info("Reauthenticating to Hub")
-        with self.timings.start("hub_reauth"):
-            await self._client.hub_login()
-
-    async def stop(self) -> None:
-        with self.timings.start("delete_lab_on_stop"):
-            await self._client.delete_lab()
-        await self._client.close()
+            self.logger.info("Reauthenticating to Hub")
+            with self.timings.start("hub_reauth"):
+                await self._client.hub_login()

--- a/src/mobu/business/notebookrunner.py
+++ b/src/mobu/business/notebookrunner.py
@@ -6,7 +6,6 @@ the notebooks, and run them on the remote Jupyter lab.
 
 from __future__ import annotations
 
-import asyncio
 import json
 import os
 from pathlib import Path
@@ -17,7 +16,7 @@ import git
 
 from ..jupyterclient import JupyterLabSession, NotebookException
 from ..models.business import BusinessData
-from .jupyterloginloop import JupyterLoginLoop
+from .jupyterpythonloop import JupyterPythonLoop
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Iterator, List, Optional
@@ -30,7 +29,7 @@ if TYPE_CHECKING:
 __all__ = ["NotebookRunner"]
 
 
-class NotebookRunner(JupyterLoginLoop):
+class NotebookRunner(JupyterPythonLoop):
     """Start a Jupyter lab and run a sequence of notebooks."""
 
     def __init__(
@@ -47,31 +46,6 @@ class NotebookRunner(JupyterLoginLoop):
         self._repo: Optional[git.Repo] = None
         self._notebook_iterator: Optional[Iterator[os.DirEntry]] = None
 
-    async def run(self) -> None:
-        self.logger.info("Starting up...")
-        await self.startup()
-        while True:
-            self.logger.info("Starting next iteration")
-            try:
-                await self.lab_business()
-                self.success_count += 1
-            except NotebookException as e:
-                running_code = self.running_code
-                notebook_name = "no notebook"
-                if self.notebook:
-                    self._failed_notebooks.append(self.notebook.name)
-                    notebook_name = self.notebook.name
-                self.logger.error(f"Error running notebook: {notebook_name}")
-                self.running_code = None
-                self.failure_count += 1
-                raise NotebookException(
-                    f"Running {notebook_name}: '"
-                    f"```{running_code}``` generated: ```{e}```"
-                )
-            except Exception:
-                self.failure_count += 1
-                raise
-
     async def startup(self) -> None:
         if not self._repo:
             self.clone_repo()
@@ -87,38 +61,28 @@ class NotebookRunner(JupyterLoginLoop):
         with self.timings.start("clone_repo"):
             self._repo = git.Repo.clone_from(url, path, branch=branch)
 
-    async def initial_delete_lab(self) -> None:
-        with self.timings.start("initial_delete_lab"):
-            await self._client.delete_lab()
-
-    async def lab_business(self) -> None:
+    async def execute_code(self, session: JupyterLabSession) -> None:
         self._next_notebook()
         assert self.notebook
-
-        await self.ensure_lab()
-        await self.lab_settle()
-        session = await self.create_session()
-
         self.logger.info(f"Starting notebook: {self.notebook.name}")
         cells = self.read_notebook(self.notebook.name, self.notebook.path)
-        for count in range(self.config.notebook_iterations):
-            iteration = f"{count + 1}/{self.config.notebook_iterations}"
+        for count in range(self.config.max_executions):
+            iteration = f"{count + 1}/{self.config.max_executions}"
             msg = f"Notebook '{self.notebook.name}' iteration {iteration}"
             self.logger.info(msg)
             await self.reauth_if_needed()
 
             for cell in cells:
                 self.running_code = "".join(cell["source"])
-                await self.execute_code(session, self.running_code)
+                await self.execute_cell(session, self.running_code)
+                self.running_code = None
                 await self.execution_idle()
+                if self.stopping:
+                    break
 
-        self.running_code = None
-        await self.delete_session(session)
-        self.logger.info(f"Success running notebook: {self.notebook.name}")
-
-    async def lab_settle(self) -> None:
-        with self.timings.start("lab_settle"):
-            await asyncio.sleep(self.config.settle_time)
+            if self.stopping:
+                break
+            self.logger.info(f"Success running notebook: {self.notebook.name}")
 
     def read_notebook(self, name: str, path: str) -> List[Dict[str, Any]]:
         with self.timings.start(f"read_notebook:{name}"):
@@ -127,27 +91,36 @@ class NotebookRunner(JupyterLoginLoop):
         return [c for c in cells if c["cell_type"] == "code"]
 
     async def create_session(self) -> JupyterLabSession:
+        """Override create_session to add the notebook name."""
         self.logger.info("create_session")
         notebook_name = self.notebook.name if self.notebook else None
         with self.timings.start("create_session"):
             session = await self._client.create_labsession(
-                notebook_name=notebook_name,
+                notebook_name=notebook_name
             )
         return session
 
-    async def execute_code(
+    async def execute_cell(
         self, session: JupyterLabSession, code: str
     ) -> None:
         self.logger.info("Executing:\n%s\n", code)
-        with self.timings.start("run_code", {"code": code}) as sw:
-            reply = await self._client.run_python(session, code)
-            sw.annotation["result"] = reply
-        self.logger.info(f"Result:\n{reply}\n")
-
-    async def delete_session(self, session: JupyterLabSession) -> None:
-        self.logger.info(f"Deleting session {session}")
-        with self.timings.start("delete_session"):
-            await self._client.delete_labsession(session)
+        try:
+            with self.timings.start("run_code", {"code": code}) as sw:
+                reply = await self._client.run_python(session, code)
+                sw.annotation["result"] = reply
+            self.logger.info(f"Result:\n{reply}\n")
+        except NotebookException as e:
+            running_code = self.running_code
+            notebook_name = "no notebook"
+            if self.notebook:
+                self._failed_notebooks.append(self.notebook.name)
+                notebook_name = self.notebook.name
+            self.logger.error(f"Error running notebook: {notebook_name}")
+            self.running_code = None
+            raise NotebookException(
+                f"Running {notebook_name}: '"
+                f"```{running_code}``` generated: ```{e}```"
+            )
 
     def dump(self) -> BusinessData:
         data = super().dump()
@@ -162,8 +135,6 @@ class NotebookRunner(JupyterLoginLoop):
             while not self.notebook.path.endswith(".ipynb"):
                 self.notebook = next(self._notebook_iterator)
         except StopIteration:
-            self.logger.info(
-                "Done with this cycle of notebooks, recreating lab."
-            )
+            self.logger.info("Done with this cycle of notebooks")
             self._notebook_iterator = os.scandir(self._repo_dir.name)
             self._next_notebook()

--- a/src/mobu/business/notebookrunner.py
+++ b/src/mobu/business/notebookrunner.py
@@ -61,14 +61,16 @@ class NotebookRunner(JupyterPythonLoop):
             self._repo = git.Repo.clone_from(url, path, branch=branch)
 
     async def execute_code(self, session: JupyterLabSession) -> None:
-        self._next_notebook()
-        assert self.notebook
-        self.logger.info(f"Starting notebook: {self.notebook.name}")
-        cells = self.read_notebook(self.notebook.name, self.notebook.path)
         for count in range(self.config.max_executions):
+            self._next_notebook()
+            assert self.notebook
+            self.logger.info(f"Starting notebook: {self.notebook.name}")
+            cells = self.read_notebook(self.notebook.name, self.notebook.path)
+
             iteration = f"{count + 1}/{self.config.max_executions}"
             msg = f"Notebook '{self.notebook.name}' iteration {iteration}"
             self.logger.info(msg)
+
             await self.reauth_if_needed()
 
             for cell in cells:

--- a/src/mobu/business/notebookrunner.py
+++ b/src/mobu/business/notebookrunner.py
@@ -71,8 +71,6 @@ class NotebookRunner(JupyterPythonLoop):
             msg = f"Notebook '{self.notebook.name}' iteration {iteration}"
             self.logger.info(msg)
 
-            await self.reauth_if_needed()
-
             for cell in cells:
                 self.running_code = "".join(cell["source"])
                 await self.execute_cell(session, self.running_code)

--- a/src/mobu/business/notebookrunner.py
+++ b/src/mobu/business/notebookrunner.py
@@ -52,7 +52,6 @@ class NotebookRunner(JupyterPythonLoop):
         self._notebook_iterator = os.scandir(self._repo_dir.name)
         self.logger.info("Repository cloned and ready")
         await super().startup()
-        await self.initial_delete_lab()
 
     def clone_repo(self) -> None:
         url = self.config.repo_url

--- a/src/mobu/business/querymonkey.py
+++ b/src/mobu/business/querymonkey.py
@@ -69,22 +69,15 @@ class QueryMonkey(Business):
 
         return pyvo.dal.TAPService(tap_url, auth)
 
-    async def run(self) -> None:
-        self.logger.info("Starting up...")
+    async def startup(self) -> None:
         templates = self._env.list_templates()
         self.logger.info("Query templates to choose from: %s", templates)
 
-        while True:
-            template_name = random.choice(self._env.list_templates())
-            template = self._env.get_template(template_name)
-            query = template.render(generate_parameters())
-            try:
-                await self.run_query(query)
-                self.success_count += 1
-            except Exception:
-                self.failure_count += 1
-                raise
-            await asyncio.sleep(60)
+    async def execute(self) -> None:
+        template_name = random.choice(self._env.list_templates())
+        template = self._env.get_template(template_name)
+        query = template.render(generate_parameters())
+        await self.run_query(query)
 
     async def run_query(self, query: str) -> None:
         self.logger.info("Running: %s", query)
@@ -93,13 +86,3 @@ class QueryMonkey(Business):
             await loop.run_in_executor(None, self._client.search, query)
             elapsed = sw.elapsed.total_seconds()
         self.logger.info(f"Query finished after {elapsed} seconds")
-
-    async def stop(self) -> None:
-        # There's nothing to do since we use synchronous queries.  If we use
-        # async queries, this should do:
-        #
-        # loop = asyncio.get_event_loop()
-        # with self.timings.start("delete_tap_client_on_stop"):
-        #     await loop.run_in_executor(None, self._client.abort)
-        #     await loop.run_in_executor(None, self._client.delete)
-        pass

--- a/src/mobu/dependencies/manager.py
+++ b/src/mobu/dependencies/manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Dict, List, Optional
 
 from aiohttp import ClientSession
@@ -30,9 +31,8 @@ class MonkeyBusinessManager:
         self._session = ClientSession()
 
     async def cleanup(self) -> None:
-        for flock in self._flocks.values():
-            await flock.stop()
-        self._flocks.clear()
+        awaits = [self.stop_flock(f) for f in self._flocks]
+        await asyncio.gather(*awaits)
         if self._scheduler is not None:
             await self._scheduler.close()
             self._scheduler = None
@@ -63,8 +63,8 @@ class MonkeyBusinessManager:
         flock = self._flocks.get(name)
         if flock is None:
             raise FlockNotFoundException(name)
-        await flock.stop()
         del self._flocks[name]
+        await flock.stop()
 
 
 monkey_business_manager = MonkeyBusinessManager()

--- a/src/mobu/dependencies/manager.py
+++ b/src/mobu/dependencies/manager.py
@@ -30,13 +30,15 @@ class MonkeyBusinessManager:
         self._session = ClientSession()
 
     async def cleanup(self) -> None:
+        for flock in self._flocks.values():
+            await flock.stop()
+        self._flocks.clear()
         if self._scheduler is not None:
             await self._scheduler.close()
             self._scheduler = None
         if self._session:
             await self._session.close()
             self._session = None
-        self._flocks.clear()
 
     async def start_flock(self, flock_config: FlockConfig) -> Flock:
         if self._scheduler is None or not self._session:

--- a/src/mobu/jupyterclient.py
+++ b/src/mobu/jupyterclient.py
@@ -174,9 +174,7 @@ class JupyterClient:
 
     async def spawn_lab(self) -> None:
         spawn_url = self.jupyter_url + "hub/spawn"
-        pending_url = (
-            self.jupyter_url + f"hub/spawn-pending/{self.user.username}"
-        )
+        hub_url = self.jupyter_url + "hub"
         lab_url = self.jupyter_url + f"user/{self.user.username}/lab"
 
         # DM-23864: Do a get on the spawn URL even if I don't have to.
@@ -202,7 +200,7 @@ class JupyterClient:
         retries = max_poll_secs / poll_interval
 
         while retries > 0:
-            async with self.session.get(pending_url) as r:
+            async with self.session.get(hub_url) as r:
                 if str(r.url) == lab_url:
                     self.log.info(f"Lab spawned, redirected to {r.url}")
                     return

--- a/src/mobu/jupyterclient.py
+++ b/src/mobu/jupyterclient.py
@@ -315,8 +315,9 @@ class JupyterClient:
             r = await session.websocket.receive_json()
             self.log.debug(f"Recieved kernel message: {r}")
             msg_type = r["msg_type"]
-            if msg_id != r["parent_header"]["msg_id"]:
-                self.log.warning(f"Unexpected kernel message: {r}", r)
+            if r["parent_header"]["msg_id"] != msg_id:
+                # Ignore messages not intended for us. The web socket is
+                # rather chatty with broadcast status messages.
                 continue
             if msg_type == "error":
                 error_message = "".join(r["content"]["traceback"])

--- a/src/mobu/jupyterclient.py
+++ b/src/mobu/jupyterclient.py
@@ -268,6 +268,7 @@ class JupyterClient:
         return await self.session.ws_connect(channels_url)
 
     async def delete_labsession(self, session: JupyterLabSession) -> None:
+        await self.lab_login()
         session_url = (
             self.jupyter_url
             + f"user/{self.user.username}/api/sessions/{session.session_id}"

--- a/src/mobu/models/business.py
+++ b/src/mobu/models/business.py
@@ -29,16 +29,6 @@ class BusinessConfig(BaseModel):
         default_factory=dict, title="Values to POST to the spawn options form"
     )
 
-    notebook_iterations: int = Field(
-        1,
-        title="How many iterations through the notebooks",
-        description=(
-            "After each iteration, the kernel is restarted."
-            " Only used by the NotebookRunner."
-        ),
-        example=10,
-    )
-
     code: str = Field(
         "print(2+2)",
         title="Python code to execute",
@@ -61,37 +51,71 @@ class BusinessConfig(BaseModel):
     settle_time: int = Field(
         10,
         title="How long to wait after lab creation in seconds",
-        description="Only used by the NotebookRunner",
+        description=(
+            "Only used by the NotebookRunner. It will wait for this long"
+            " after lab creation before trying to create a session."
+        ),
         example=10,
     )
 
-    lab_idle_time: int = Field(
-        20,
-        title="How long to wait at end of lab loop in seconds",
-        description="Used by JupyterLoginLoop",
-        example=20,
+    idle_time: int = Field(
+        60,
+        title="How long to wait between business executions",
+        description=(
+            "AFter each loop executing monkey business, the monkey will"
+            " pause for this long in seconds"
+        ),
+        example=60,
+    )
+
+    login_idle_time: int = Field(
+        60,
+        title="Time to pause after spawning lab",
+        description=(
+            "Only used by JupyterLoginLoop and JupyterJitterLoginLoop."
+            " How long to wait after spawning the lab before destroying"
+            " it again."
+        ),
+        example=60,
     )
 
     execution_idle_time: int = Field(
-        0,
+        1,
         title="How long to wait between cell executions in seconds",
         description="Used by JupyterPythonLoop and NotebookRunner",
         example=1,
     )
 
     reauth_interval: int = Field(
-        2700,
+        30 * 60,
         title="Time between reauthentication attempts in seconds",
-        description="Used by JupyterLoginLoop, JupyterPythonLoop, and"
-        " NotebookRunner",
-        example=2700,
+        description=(
+            "Used by JupyterLoginLoop, JupyterPythonLoop, and NotebookRunner."
+            " JupyterHub appears to issue tokens with a one hour lifetime."
+        ),
+        example=30 * 60,
     )
 
     max_executions: int = Field(
         25,
-        title="How many cells to execute in a given kernel session",
-        description="Only used by JupyterPythonLoop",
+        title="How much to execute in a given lab and session",
+        description=(
+            "For JupyterPythonLoop, this is the number of code snippets to"
+            " execute before restarting the lab. For NotebookRunner, it's"
+            " the number of notebooks."
+        ),
         example=25,
+    )
+
+    delete_lab: bool = Field(
+        True,
+        title="Whether to delete the lab between iterations",
+        description=(
+            "By default, the lab is deleted and recreated after each"
+            " iteration of monkey business involving JupyterLab. Set this"
+            " to False to keep the same lab."
+        ),
+        example=True,
     )
 
 

--- a/src/mobu/models/business.py
+++ b/src/mobu/models/business.py
@@ -52,8 +52,7 @@ class BusinessConfig(BaseModel):
         10,
         title="How long to wait after lab creation in seconds",
         description=(
-            "Only used by the NotebookRunner. It will wait for this long"
-            " after lab creation before trying to create a session."
+            "Wait this long after lag creation before trying to use the lab"
         ),
         example=10,
     )

--- a/src/mobu/models/business.py
+++ b/src/mobu/models/business.py
@@ -30,10 +30,10 @@ class BusinessConfig(BaseModel):
     )
 
     code: str = Field(
-        "print(2+2)",
+        'print(2+2, end="")',
         title="Python code to execute",
         description="Only used by JupyterPythonLoop",
-        example="print(2+2)",
+        example='print(2+2, end="")',
     )
 
     repo_url: str = Field(

--- a/src/mobu/models/business.py
+++ b/src/mobu/models/business.py
@@ -52,7 +52,7 @@ class BusinessConfig(BaseModel):
         10,
         title="How long to wait after lab creation in seconds",
         description=(
-            "Wait this long after lag creation before trying to use the lab"
+            "Wait this long after lab creation before trying to use the lab"
         ),
         example=10,
     )
@@ -101,7 +101,13 @@ class BusinessConfig(BaseModel):
         description=(
             "For JupyterPythonLoop, this is the number of code snippets to"
             " execute before restarting the lab. For NotebookRunner, it's"
-            " the number of notebooks."
+            " the number of complete notebooks. NotebookRunner goes through"
+            " the directory of notebooks one-by-one, running the entirety"
+            " of each one and starting again at the beginning of the list"
+            " when it runs out, until it has executed a total of"
+            " max_executions notebooks. It then closes the session (and"
+            " optionally deletes and recreates the lab, controlled by"
+            " delete_lab), and then picks up where it left off."
         ),
         example=25,
     )

--- a/src/mobu/monkey.py
+++ b/src/mobu/monkey.py
@@ -116,7 +116,6 @@ class Monkey:
                 run = self.restart and self.state == MonkeyState.RUNNING
                 if self.state == MonkeyState.RUNNING:
                     self.state = MonkeyState.ERROR
-                await self.business.stop()
             if run:
                 await asyncio.sleep(60)
 

--- a/tests/autostart_test.py
+++ b/tests/autostart_test.py
@@ -47,7 +47,7 @@ AUTOSTART_CONFIG = """
 
 @pytest.fixture(autouse=True)
 def configure_autostart(
-    tmp_path: Path, jupyter: None, mock_aioresponses: aioresponses
+    tmp_path: Path, mock_aioresponses: aioresponses
 ) -> Iterator[None]:
     """Set up the autostart configuration."""
     mock_gafaelfawr(mock_aioresponses)

--- a/tests/business/jupyterloginloop_test.py
+++ b/tests/business/jupyterloginloop_test.py
@@ -9,15 +9,18 @@ from unittest.mock import ANY
 import pytest
 
 from tests.support.gafaelfawr import mock_gafaelfawr
+from tests.support.jupyter import JupyterState
 
 if TYPE_CHECKING:
     from aioresponses import aioresponses
     from httpx import AsyncClient
 
+    from tests.support.jupyter import MockJupyter
+
 
 @pytest.mark.asyncio
 async def test_run(
-    client: AsyncClient, jupyter: None, mock_aioresponses: aioresponses
+    client: AsyncClient, jupyter: MockJupyter, mock_aioresponses: aioresponses
 ) -> None:
     mock_gafaelfawr(mock_aioresponses)
 
@@ -28,7 +31,7 @@ async def test_run(
             "count": 1,
             "user_spec": {"username_prefix": "testuser", "uid_start": 1000},
             "scopes": ["exec:notebook"],
-            "options": {"idle_time": 2},
+            "options": {"settle_time": 0, "login_idle_time": 0},
             "business": "JupyterLoginLoop",
         },
     )
@@ -37,7 +40,7 @@ async def test_run(
     # Wait until we've finished at least one loop.  Make sure nothing fails.
     finished = False
     while not finished:
-        await asyncio.sleep(1)
+        await asyncio.sleep(0.5)
         r = await client.get("/mobu/flocks/test/monkeys/testuser1")
         assert r.status_code == 200
         data = r.json()
@@ -52,7 +55,7 @@ async def test_run(
         "business": {
             "failure_count": 0,
             "name": "JupyterLoginLoop",
-            "success_count": ANY,
+            "success_count": 1,
             "timings": ANY,
         },
         "restart": False,
@@ -65,6 +68,9 @@ async def test_run(
         },
     }
 
+    # Check that the lab is shut down properly between iterations.
+    assert jupyter.state["testuser1"] == JupyterState.LOGGED_IN
+
     r = await client.get("/mobu/flocks/test/monkeys/testuser1/log")
     assert r.status_code == 200
     assert "Starting up" in r.text
@@ -72,3 +78,39 @@ async def test_run(
 
     r = await client.delete("/mobu/flocks/test")
     assert r.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_reuse_lab(
+    client: AsyncClient, jupyter: MockJupyter, mock_aioresponses: aioresponses
+) -> None:
+    mock_gafaelfawr(mock_aioresponses)
+
+    r = await client.put(
+        "/mobu/flocks",
+        json={
+            "name": "test",
+            "count": 1,
+            "user_spec": {"username_prefix": "testuser", "uid_start": 1000},
+            "scopes": ["exec:notebook"],
+            "options": {
+                "settle_time": 0,
+                "login_idle_time": 0,
+                "delete_lab": False,
+            },
+            "business": "JupyterLoginLoop",
+        },
+    )
+    assert r.status_code == 201
+
+    # Wait until we've finished at least one loop.  Make sure nothing fails.
+    finished = False
+    while not finished:
+        await asyncio.sleep(0.5)
+        r = await client.get("/mobu/flocks/test/monkeys/testuser1")
+        assert r.status_code == 200
+        if r.json()["business"]["success_count"] > 0:
+            finished = True
+
+    # Check that the lab is still running between iterations.
+    assert jupyter.state["testuser1"] == JupyterState.LAB_RUNNING

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ from mobu import main
 from mobu.config import config
 from mobu.jupyterclient import JupyterClient
 from tests.support.gafaelfawr import make_gafaelfawr_token
-from tests.support.jupyter import mock_jupyter
+from tests.support.jupyter import MockJupyter, mock_jupyter
 
 if TYPE_CHECKING:
     from typing import AsyncIterator, Iterator
@@ -33,7 +33,7 @@ def configure() -> Iterator[None]:
     minimal test configuration and a unique admin token that is replaced after
     the test runs.
     """
-    config.environment_url = "https://test.example.com/"
+    config.environment_url = "https://test.example.com"
     config.gafaelfawr_token = make_gafaelfawr_token()
     yield
     config.environment_url = ""
@@ -41,11 +41,17 @@ def configure() -> Iterator[None]:
 
 
 @pytest.fixture
-async def app() -> AsyncIterator[FastAPI]:
+async def app(jupyter: MockJupyter) -> AsyncIterator[FastAPI]:
     """Return a configured test application.
 
     Wraps the application in a lifespan manager so that startup and shutdown
     events are sent during test execution.
+
+    Notes
+    -----
+    This must depend on the Jupyter mock since otherwise the JupyterClient
+    mocking is undone before the app is shut down, which causes it to try to
+    make real web socket calls.
     """
     async with LifespanManager(main.app):
         yield main.app
@@ -59,9 +65,9 @@ async def client(app: FastAPI) -> AsyncIterator[AsyncClient]:
 
 
 @pytest.fixture
-def jupyter(mock_aioresponses: aioresponses) -> Iterator[None]:
+def jupyter(mock_aioresponses: aioresponses) -> Iterator[MockJupyter]:
     """Mock out JupyterHub/Lab."""
-    mock_jupyter(mock_aioresponses)
+    jupyter_mock = mock_jupyter(mock_aioresponses)
 
     # aioresponses has no mechanism to mock ws_connect, so we can't properly
     # test JupyterClient.run_python.  For now, just mock it out entirely.
@@ -71,7 +77,7 @@ def jupyter(mock_aioresponses: aioresponses) -> Iterator[None]:
         # reusing the websocket.
         with patch.object(JupyterClient, "_websocket_connect") as mock2:
             mock2.return_value = AsyncMock()
-            yield
+            yield jupyter_mock
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,8 +52,11 @@ async def app(jupyter: MockJupyter) -> AsyncIterator[FastAPI]:
     This must depend on the Jupyter mock since otherwise the JupyterClient
     mocking is undone before the app is shut down, which causes it to try to
     make real web socket calls.
+
+    A tests in business/jupyterloginloop_test.py depends on the exact shutdown
+    timeout.
     """
-    async with LifespanManager(main.app):
+    async with LifespanManager(main.app, shutdown_timeout=10):
         yield main.app
 
 

--- a/tests/handlers/flock_test.py
+++ b/tests/handlers/flock_test.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 @pytest.mark.asyncio
 async def test_start_stop(
-    client: AsyncClient, jupyter: None, mock_aioresponses: aioresponses
+    client: AsyncClient, mock_aioresponses: aioresponses
 ) -> None:
     mock_gafaelfawr(mock_aioresponses)
 
@@ -46,7 +46,7 @@ async def test_start_stop(
                 "business": {
                     "failure_count": 0,
                     "name": "Business",
-                    "success_count": 0,
+                    "success_count": ANY,
                     "timings": ANY,
                 },
                 "restart": False,
@@ -116,7 +116,7 @@ async def test_start_stop(
 
 @pytest.mark.asyncio
 async def test_user_list(
-    client: AsyncClient, jupyter: None, mock_aioresponses: aioresponses
+    client: AsyncClient, mock_aioresponses: aioresponses
 ) -> None:
     mock_gafaelfawr(mock_aioresponses)
 
@@ -147,7 +147,7 @@ async def test_user_list(
                 "business": {
                     "failure_count": 0,
                     "name": "Business",
-                    "success_count": 0,
+                    "success_count": ANY,
                     "timings": ANY,
                 },
                 "restart": False,
@@ -164,7 +164,7 @@ async def test_user_list(
                 "business": {
                     "failure_count": 0,
                     "name": "Business",
-                    "success_count": 0,
+                    "success_count": ANY,
                     "timings": ANY,
                 },
                 "restart": False,
@@ -189,13 +189,13 @@ async def test_user_list(
     assert r.status_code == 200
     assert r.json() == expected["monkeys"][1]
 
-    # Intentionally do not delete the flock to check whether aiojobs will
-    # shut down properly when the server is shut down.
+    # Intentionally do not delete the flock to check whether we shut
+    # everything down properly when the server is shut down.
 
 
 @pytest.mark.asyncio
 async def test_errors(
-    client: AsyncClient, jupyter: None, mock_aioresponses: aioresponses
+    client: AsyncClient, mock_aioresponses: aioresponses
 ) -> None:
     mock_gafaelfawr(mock_aioresponses)
 

--- a/tests/monkeyflocker_test.py
+++ b/tests/monkeyflocker_test.py
@@ -144,7 +144,7 @@ def test_start_report_stop(tmp_path: Path, app_url: str) -> None:
                 "business": {
                     "failure_count": 0,
                     "name": "Business",
-                    "success_count": 0,
+                    "success_count": ANY,
                     "timings": ANY,
                 },
                 "restart": False,

--- a/tests/support/jupyter.py
+++ b/tests/support/jupyter.py
@@ -64,7 +64,7 @@ class MockJupyter:
         elif state == JupyterState.SPAWN_PENDING:
             redirect_to = _url(f"hub/spawn-pending/{user}")
         elif state == JupyterState.LAB_RUNNING:
-            redirect_to = _url(f"hub/spawn-pending/{user}")
+            redirect_to = _url(f"user/{user}/lab")
         return CallbackResult(status=307, headers={"Location": redirect_to})
 
     def spawn(self, url: str, **kwargs: Any) -> CallbackResult:


### PR DESCRIPTION
- Add proper shutdown support for monkeys using a queue to coordinate
- Refactor the business classes more to reuse more code and better document overrides
- Make shutting down the lab between notebook executions optional
- Use max_interations for NotebookRunner as well, instead of its own config variable
- Lift more infrastructure into the base business class
- Reauthenticate to the lab before deleting a session
- Poll the hub URL instead of the pending spawn URL to see if the lab is up since the latter sometimes 503s
- Make the default JupyterPythonLoop code produce cleaner logs
- Fix desynchronization of the web socket that caused the results of code execution to be lost
- Remove the periodic hub reauth code (should now be unnecessary)
- Wait for the lab to shut down after deletion
- Be more precise when checking if the lab is running