### PR TITLE
[DM-31490] Overhaul how Jupyter images are selected

### DIFF
--- a/src/mobu/business/notebookrunner.py
+++ b/src/mobu/business/notebookrunner.py
@@ -45,6 +45,12 @@ class NotebookRunner(JupyterPythonLoop):
         self._repo: Optional[git.Repo] = None
         self._notebook_paths: Optional[List[Path]] = None
 
+    def annotations(self) -> Dict[str, str]:
+        result = super().annotations()
+        if self.notebook:
+            result["notebook"] = self.notebook.name
+        return result
+
     async def startup(self) -> None:
         if not self._repo:
             self.clone_repo()
@@ -136,9 +142,8 @@ class NotebookRunner(JupyterPythonLoop):
     ) -> None:
         assert self.notebook
         self.logger.info("Executing:\n%s\n", code)
-        annotations = {"notebook": self.notebook.name, "cell": cell_id}
-        if self.node:
-            annotations["node"] = self.node
+        annotations = self.annotations()
+        annotations["cell"] = cell_id
         with self.timings.start("execute_cell", annotations):
             self.running_code = code
             reply = await self._client.run_python(session, code)

--- a/src/mobu/cachemachine.py
+++ b/src/mobu/cachemachine.py
@@ -1,0 +1,83 @@
+"""Client for the cachemachine service."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import urljoin
+
+from .config import config
+from .exceptions import CachemachineError
+from .models.jupyter import JupyterImage
+
+if TYPE_CHECKING:
+    from typing import List
+
+    from aiohttp import ClientSession
+
+
+class CachemachineClient:
+    """Query the cachemachine service for image information.
+
+    Cachemachine is canonical for the available images and details such as
+    which image is recommended and what the latest weeklies are.  This client
+    queries it and returns the image that matches some selection criteria.
+    The resulting string can be passed in to the JupyterHub options form.
+    """
+
+    def __init__(self, session: ClientSession, token: str) -> None:
+        self._session = session
+        self._token = token
+        self._url = urljoin(
+            config.environment_url, "cachemachine/jupyter/available"
+        )
+
+    async def get_latest_weekly(self) -> JupyterImage:
+        """Image for the latest weekly version.
+
+        Returns
+        -------
+        image : `mobu.models.jupyter.JupyterImage`
+            The corresponding image.
+
+        Raises
+        ------
+        mobu.exceptions.CachemachineError
+            Some error occurred talking to cachemachine or cachemachine does
+            not have any weekly images.
+        """
+        for image in await self._get_images():
+            if image.name.startswith("Weekly"):
+                return image
+        raise CachemachineError("No weekly versions found")
+
+    async def get_recommended(self) -> JupyterImage:
+        """Image string for the latest recommended version.
+
+        Returns
+        -------
+        image : `mobu.models.jupyter.JupyterImage`
+            The corresponding image.
+
+        Raises
+        ------
+        mobu.exceptions.CachemachineError
+            Some error occurred talking to cachemachine.
+        """
+        images = await self._get_images()
+        return images[0]
+
+    async def _get_images(self) -> List[JupyterImage]:
+        headers = {"Authorization": f"bearer {self._token}"}
+        async with self._session.get(self._url, headers=headers) as r:
+            if r.status != 200:
+                msg = (
+                    "Cannot get image status from cachemachine: "
+                    f"{r.status} {r.reason}"
+                )
+                raise CachemachineError(msg)
+            try:
+                data = await r.json()
+                return [JupyterImage.from_dict(i) for i in data["images"]]
+            except Exception as e:
+                msg = f"Invalid response from cachemachine: {str(e)}"
+                raise CachemachineError(msg)

--- a/src/mobu/models/jupyter.py
+++ b/src/mobu/models/jupyter.py
@@ -1,0 +1,98 @@
+"""Models for configuring a Jupyter lab."""
+
+from enum import Enum
+from typing import Dict, Optional
+
+from pydantic import BaseModel, Field, validator
+
+__all__ = ["JupyterConfig", "JupyterImage", "JupyterImageClass"]
+
+
+class JupyterImageClass(Enum):
+    """Possible ways of selecting an image."""
+
+    RECOMMENDED = "recommended"
+    LATEST_WEEKLY = "latest-weekly"
+    BY_REFERENCE = "by-reference"
+
+
+class JupyterImage(BaseModel):
+    """Represents an image to spawn as a Jupyter Lab."""
+
+    reference: str = Field(
+        ...,
+        title="Docker reference for the image",
+        example="registry.hub.docker.com/lsstsqre/sciplat-lab:w_2021_13",
+    )
+
+    name: str = Field(
+        ...,
+        title="Human-readable name for the image",
+        example="Weekly 2021_34",
+    )
+
+    digest: Optional[str] = Field(
+        ...,
+        title="Hash of the last layer of the Docker container",
+        description="May be null if the digest isn't known",
+        example=(
+            "sha256:419c4b7e14603711b25fa9e0569460a753c4b2449fe275bb5f89743b"
+            "01794a30"
+        ),
+    )
+
+    def __str__(self) -> str:
+        return "|".join([self.reference, self.name, self.digest or ""])
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, str]) -> "JupyterImage":
+        return JupyterImage(
+            reference=data["image_url"],
+            name=data["name"],
+            digest=data["image_hash"],
+        )
+
+    @classmethod
+    def from_reference(cls, reference: str) -> "JupyterImage":
+        return cls(
+            reference=reference, name=reference.rsplit(":", 1)[1], digest=""
+        )
+
+
+class JupyterConfig(BaseModel):
+    """Configuration for talking to JupyterHub and spawning a lab.
+
+    Settings are divided between here and the main BusinessConfig somewhat
+    arbitrarily, but the underlying concept is that these settings are used by
+    the spawner and API and the settings in BusinessConfig control behavior
+    outside of the API calls to JupyterHub.
+    """
+
+    url_prefix: str = Field("/nb/", title="URL prefix for Jupyter")
+
+    image_class: JupyterImageClass = Field(
+        JupyterImageClass.RECOMMENDED,
+        title="How to select the image to spawn",
+        description="Only used by JupyterLoginLoop and its subclasses",
+    )
+
+    image_reference: Optional[str] = Field(
+        None,
+        title="Docker reference of lab image to spawn",
+        description="Only used if jupyter_image is set to by-reference",
+    )
+
+    image_size: str = Field(
+        "Large",
+        title="Size of image to spawn",
+        description="Must be one of the sizes in the nublado2 configuration",
+    )
+
+    @validator("image_reference")
+    def _valid_image_reference(
+        cls, v: Optional[str], values: Dict[str, object]
+    ) -> Optional[str]:
+        if values.get("image_class") == JupyterImageClass.BY_REFERENCE:
+            if not v:
+                raise ValueError("image_reference required")
+        return v

--- a/tests/autostart_test.py
+++ b/tests/autostart_test.py
@@ -34,10 +34,9 @@ AUTOSTART_CONFIG = """
     - username: otherpython
       uidnumber: 70000
   options:
-    jupyter_options_form:
-      image: "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended"
-      image_dropdown: use_image_from_dropdown
-      size: Small
+    jupyter:
+      image_class: latest-weekly
+      image_size: Large
     spawn_settle_time: 10
   scopes: ["exec:notebook"]
   restart: true
@@ -115,13 +114,9 @@ async def test_autostart(client: AsyncClient) -> None:
             "restart": True,
             "business": "JupyterPythonLoop",
             "options": {
-                "jupyter_options_form": {
-                    "image": (
-                        "registry.hub.docker.com/lsstsqre/sciplat-lab"
-                        ":recommended"
-                    ),
-                    "image_dropdown": "use_image_from_dropdown",
-                    "size": "Small",
+                "jupyter": {
+                    "image_class": "latest-weekly",
+                    "image_size": "Large",
                 },
                 "spawn_settle_time": 10,
             },
@@ -131,6 +126,14 @@ async def test_autostart(client: AsyncClient) -> None:
                 "name": "python",
                 "business": {
                     "failure_count": 0,
+                    "image": {
+                        "digest": ANY,
+                        "name": "Weekly 2021_35",
+                        "reference": (
+                            "registry.hub.docker.com/lsstsqre/sciplat-lab"
+                            ":w_2021_35"
+                        ),
+                    },
                     "name": "JupyterPythonLoop",
                     "success_count": ANY,
                     "timings": ANY,
@@ -148,6 +151,14 @@ async def test_autostart(client: AsyncClient) -> None:
                 "name": "otherpython",
                 "business": {
                     "failure_count": 0,
+                    "image": {
+                        "digest": ANY,
+                        "name": "Weekly 2021_35",
+                        "reference": (
+                            "registry.hub.docker.com/lsstsqre/sciplat-lab"
+                            ":w_2021_35"
+                        ),
+                    },
                     "name": "JupyterPythonLoop",
                     "success_count": ANY,
                     "timings": ANY,

--- a/tests/business/jupyterloginloop_test.py
+++ b/tests/business/jupyterloginloop_test.py
@@ -383,6 +383,11 @@ async def test_delete_timeout(
                         {"type": "mrkdwn", "text": ANY},
                         {"type": "mrkdwn", "text": "*User*\ntestuser1"},
                         {"type": "mrkdwn", "text": "*Event*\ndelete_lab"},
+                        {
+                            "type": "mrkdwn",
+                            "text": "*Image*\nRecommended (Weekly 2021_33)",
+                            "verbatim": True,
+                        },
                     ],
                 },
                 {"type": "divider"},

--- a/tests/business/jupyterpythonloop_test.py
+++ b/tests/business/jupyterpythonloop_test.py
@@ -146,6 +146,11 @@ async def test_alert(
                         {"type": "mrkdwn", "text": ANY},
                         {"type": "mrkdwn", "text": "*User*\ntestuser1"},
                         {"type": "mrkdwn", "text": "*Event*\nexecute_code"},
+                        {
+                            "type": "mrkdwn",
+                            "text": "*Image*\nRecommended (Weekly 2021_33)",
+                            "verbatim": True,
+                        },
                         {"type": "mrkdwn", "text": "*Node*\nsome-node"},
                     ],
                 },

--- a/tests/business/notebookrunner_test.py
+++ b/tests/business/notebookrunner_test.py
@@ -143,6 +143,13 @@ async def test_alert(
         "name": "testuser1",
         "business": {
             "failure_count": 1,
+            "image": {
+                "digest": ANY,
+                "name": "Recommended (Weekly 2021_33)",
+                "reference": (
+                    "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended"
+                ),
+            },
             "name": "NotebookRunner",
             "notebook": "exception.ipynb",
             "running_code": bad_code,
@@ -179,10 +186,15 @@ async def test_alert(
                         {"type": "mrkdwn", "text": "*Event*\nexecute_cell"},
                         {
                             "type": "mrkdwn",
-                            "text": "*Cell id*\n`ed399c0a` (#2)",
+                            "text": "*Image*\nRecommended (Weekly 2021_33)",
                             "verbatim": True,
                         },
                         {"type": "mrkdwn", "text": "*Node*\nsome-node"},
+                        {
+                            "type": "mrkdwn",
+                            "text": "*Cell id*\n`ed399c0a` (#2)",
+                            "verbatim": True,
+                        },
                     ],
                 },
             ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ from httpx import AsyncClient
 
 from mobu import main
 from mobu.config import config
+from tests.support.cachemachine import mock_cachemachine
 from tests.support.gafaelfawr import make_gafaelfawr_token
 from tests.support.jupyter import mock_jupyter, mock_jupyter_websocket
 from tests.support.slack import mock_slack
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
 
     from fastapi import FastAPI
 
+    from tests.support.cachemachine import MockCachemachine
     from tests.support.jupyter import MockJupyter, MockJupyterWebSocket
     from tests.support.slack import MockSlack
 
@@ -45,7 +47,9 @@ def configure() -> Iterator[None]:
 
 
 @pytest.fixture
-async def app(jupyter: MockJupyter) -> AsyncIterator[FastAPI]:
+async def app(
+    jupyter: MockJupyter, cachemachine: MockCachemachine
+) -> AsyncIterator[FastAPI]:
     """Return a configured test application.
 
     Wraps the application in a lifespan manager so that startup and shutdown
@@ -76,6 +80,12 @@ def mock_aioresponses() -> Iterator[aioresponses]:
     """Set up aioresponses for aiohttp mocking."""
     with aioresponses() as mocked:
         yield mocked
+
+
+@pytest.fixture
+def cachemachine(mock_aioresponses: aioresponses) -> MockCachemachine:
+    """Mock out cachemachine."""
+    return mock_cachemachine(mock_aioresponses)
 
 
 @pytest.fixture

--- a/tests/support/cachemachine.py
+++ b/tests/support/cachemachine.py
@@ -1,0 +1,97 @@
+"""Mock cachemachine for tests."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from aioresponses import CallbackResult
+
+from mobu.config import config
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from aioresponses import aioresponses
+
+__all__ = ["MockCachemachine", "mock_cachemachine"]
+
+
+class MockCachemachine:
+    """Mock of cachemachine that implements only the available image API."""
+
+    def __init__(self) -> None:
+        self.images = [
+            {
+                "image_url": (
+                    "registry.hub.docker.com/lsstsqre/sciplat-lab:recommended"
+                ),
+                "image_hash": (
+                    "sha256:c2c67ee6275b861fdf69dfbb42322925118e2b997bfe294519"
+                    "01900ba00bba69"
+                ),
+                "name": "Recommended (Weekly 2021_33)",
+            },
+            {
+                "image_url": (
+                    "registry.hub.docker.com/lsstsqre/sciplat-lab:r22_0_1"
+                ),
+                "image_hash": (
+                    "sha256:72cff1efc7ef6c31cd4afed489d58fec91bdfa4711918b240b"
+                    "548c9370914464"
+                ),
+                "name": "Release r22.0.1",
+            },
+            {
+                "image_url": (
+                    "registry.hub.docker.com/lsstsqre/sciplat-lab:w_2021_35"
+                ),
+                "image_hash": (
+                    "sha256:ef93e4560a2e06d39300802686392000237f186a9197e8dea2"
+                    "4a1dd9abbd6e2c"
+                ),
+                "name": "Weekly 2021_35",
+            },
+            {
+                "image_url": (
+                    "registry.hub.docker.com/lsstsqre/sciplat-lab:w_2021_34"
+                ),
+                "image_hash": (
+                    "sha256:513c08d9fd0fae9fdd6880bba2781d14c480eec86e7c937856"
+                    "cfac1cd1a3baac"
+                ),
+                "name": "Weekly 2021_34",
+            },
+            {
+                "image_url": (
+                    "registry.hub.docker.com/lsstsqre/sciplat-lab:d_2021_08_31"
+                ),
+                "image_hash": (
+                    "sha256:d99b6067e489657cda0835a34466756ef04e36b597587c3442"
+                    "d405457423ee9b"
+                ),
+                "name": "Daily 2021_08_31",
+            },
+            {
+                "image_url": (
+                    "registry.hub.docker.com/lsstsqre/sciplat-lab:d_2021_08_30"
+                ),
+                "image_hash": (
+                    "sha256:16fc46c35b453a2be5593e473d6b102442faaeec42ffda3394"
+                    "0f0669d2ac1f88"
+                ),
+                "name": "Daily 2021_08_30",
+            },
+        ]
+
+    def available(self, url: str, **kwargs: Any) -> CallbackResult:
+        body = {"images": self.images}
+        return CallbackResult(status=200, body=json.dumps(body))
+
+
+def mock_cachemachine(mocked: aioresponses) -> MockCachemachine:
+    """Set up a mock cachemachine."""
+    mock = MockCachemachine()
+    url = f"{config.environment_url}/cachemachine/jupyter/available"
+    mocked.get(url, callback=mock.available, repeat=True)
+    return mock


### PR DESCRIPTION
Rather than configuring mobu with the raw values to post to the
spawner form, support asking cachemachine for an image satisfying
a particular quality (recommended and latest weekly being the main
supported ones right now), and then determine the correct thing to
send to the spawner page from that.

Use this infrastructure to record the image name in error reports
and in metadata about a running monkey business.