### PR TITLE
[DM-31581] Trim errors and code to 3000 characters

### DIFF
--- a/tests/business/jupyterpythonloop_test.py
+++ b/tests/business/jupyterpythonloop_test.py
@@ -184,3 +184,99 @@ async def test_alert(
     ]
     error = slack.alerts[0]["attachments"][0]["blocks"][0]["text"]["text"]
     assert "Exception: some error" in error
+
+
+@pytest.mark.asyncio
+async def test_long_error(
+    client: AsyncClient, slack: MockSlack, mock_aioresponses: aioresponses
+) -> None:
+    mock_gafaelfawr(mock_aioresponses)
+
+    r = await client.put(
+        "/mobu/flocks",
+        json={
+            "name": "test",
+            "count": 1,
+            "user_spec": {"username_prefix": "testuser", "uid_start": 1000},
+            "scopes": ["exec:notebook"],
+            "options": {
+                "code": "long_error_for_test()",
+                "jupyter": {
+                    "image_class": "by-reference",
+                    "image_reference": (
+                        "registry.hub.docker.com/lsstsqre/sciplat-lab"
+                        ":d_2021_08_30"
+                    ),
+                },
+                "spawn_settle_time": 0,
+                "lab_settle_time": 0,
+                "max_executions": 1,
+            },
+            "business": "JupyterPythonLoop",
+        },
+    )
+    assert r.status_code == 201
+
+    # Wait until we've finished one loop.
+    data = await wait_for_business(client, "testuser1")
+    assert data["business"]["failure_count"] == 1
+
+    # Check that an appropriate error was posted.
+    error = ""
+    line = "this is a single line of output to test trimming errors"
+    for i in range(5, 54):
+        error += f"{line} #{i}\n"
+    assert 2977 - len(line) <= len(error) <= 2977
+    assert slack.alerts == [
+        {
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "Error while running code",
+                    },
+                },
+                {
+                    "type": "section",
+                    "fields": [
+                        {"type": "mrkdwn", "text": ANY},
+                        {"type": "mrkdwn", "text": ANY},
+                        {"type": "mrkdwn", "text": "*User*\ntestuser1"},
+                        {"type": "mrkdwn", "text": "*Event*\nexecute_code"},
+                        {
+                            "type": "mrkdwn",
+                            "text": "*Image*\nd_2021_08_30",
+                            "verbatim": True,
+                        },
+                        {"type": "mrkdwn", "text": "*Node*\nsome-node"},
+                    ],
+                },
+            ],
+            "attachments": [
+                {
+                    "blocks": [
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": f"*Error*\n```\n{error}```",
+                                "verbatim": True,
+                            },
+                        },
+                        {
+                            "type": "section",
+                            "text": {
+                                "type": "mrkdwn",
+                                "text": (
+                                    "*Code executed*\n"
+                                    "```\nlong_error_for_test()\n```"
+                                ),
+                                "verbatim": True,
+                            },
+                        },
+                    ]
+                }
+            ],
+        }
+    ]

--- a/tests/support/jupyter.py
+++ b/tests/support/jupyter.py
@@ -291,6 +291,17 @@ class MockJupyterWebSocket(Mock):
                 "parent_header": self._header,
                 "content": {"text": "some-node"},
             }
+        elif self._code == "long_error_for_test()":
+            self._code = None
+            error = ""
+            line = "this is a single line of output to test trimming errors"
+            for i in range(int(3000 / len(line))):
+                error += f"{line} #{i}\n"
+            return {
+                "msg_type": "error",
+                "parent_header": self._header,
+                "content": {"traceback": error},
+            }
         elif self._code:
             try:
                 output = StringIO()


### PR DESCRIPTION
Slack has a limit on block sizes of 3000 characters, but sometimes
errors can be longer than that.  Trim errors and code from the top
(since the bottom is usually more interesting) to get it below
Slack's limit so that we don't have missing alerts.