### PR TITLE
[DM-31490] Use correct token for cachemachine queries

### DIFF
--- a/src/mobu/jupyterclient.py
+++ b/src/mobu/jupyterclient.py
@@ -206,7 +206,10 @@ class JupyterClient:
 
         # We also send the XSRF token to cachemachine because of how we're
         # sharing the session, but that shouldn't matter.
-        self.cachemachine = CachemachineClient(session, user.token)
+        assert config.gafaelfawr_token
+        self.cachemachine = CachemachineClient(
+            session, config.gafaelfawr_token
+        )
 
     async def close(self) -> None:
         await self.session.close()


### PR DESCRIPTION
The regular user token cannot access cachemachine.  Use the token
that mints other user tokens instead, since we can grant it access.