### PR TITLE
DM-32329: Allow web socket messages of any size

### DIFF
--- a/src/mobu/jupyterclient.py
+++ b/src/mobu/jupyterclient.py
@@ -346,7 +346,9 @@ class JupyterClient:
             + f"{kernel_id}/channels"
         )
         try:
-            websocket = await self.session.ws_connect(channels_url, max_msg_size=0)
+            websocket = await self.session.ws_connect(
+                channels_url, max_msg_size=0
+            )
         except WSServerHandshakeError as e:
             raise JupyterError.from_exception(self.user.username, e) from None
         return JupyterLabSession(

--- a/src/mobu/jupyterclient.py
+++ b/src/mobu/jupyterclient.py
@@ -346,7 +346,7 @@ class JupyterClient:
             + f"{kernel_id}/channels"
         )
         try:
-            websocket = await self.session.ws_connect(channels_url)
+            websocket = await self.session.ws_connect(channels_url, max_msg_size=0)
         except WSServerHandshakeError as e:
             raise JupyterError.from_exception(self.user.username, e) from None
         return JupyterLabSession(


### PR DESCRIPTION
Since the JupyterLab interface doesn't impose a message size limit, it makes sense to treat the notebooks run in CI the same way.  We may want to do a sweep occasionally to see how big the messages are, but I'm not sure it's the right thing to fail on them.