### PR TITLE
[DM-35246] Add more query annotations to TAP queries

### DIFF
--- a/src/mobu/templates/tapqueryrunner/cone-object.sql
+++ b/src/mobu/templates/tapqueryrunner/cone-object.sql
@@ -1,3 +1,3 @@
-SELECT 'monkey', *
+SELECT 'monkey', 'cone-object', *
 FROM dp01_dc2_catalogs.object
 WHERE CONTAINS(POINT('ICRS', ra, dec), CIRCLE('ICRS', {{ ra }}, {{ dec }}, {{ radius }}))=1

--- a/src/mobu/templates/tapqueryrunner/cone-photometry.sql
+++ b/src/mobu/templates/tapqueryrunner/cone-photometry.sql
@@ -1,3 +1,3 @@
-SELECT 'monkey', *
+SELECT 'monkey', 'cone-photometry', *
 FROM dp01_dc2_catalogs.forced_photometry
 WHERE CONTAINS(POINT('ICRS', coord_ra, coord_dec), CIRCLE('ICRS', {{ ra }}, {{ dec }}, {{ radius }}))=1

--- a/src/mobu/templates/tapqueryrunner/cone-position.sql
+++ b/src/mobu/templates/tapqueryrunner/cone-position.sql
@@ -1,3 +1,3 @@
-SELECT 'monkey', *
+SELECT 'monkey', 'cone-position', *
 FROM dp01_dc2_catalogs.position
 WHERE CONTAINS(POINT('ICRS', coord_ra, coord_dec), CIRCLE('ICRS', {{ ra }}, {{ dec }}, {{ radius }}))=1

--- a/src/mobu/templates/tapqueryrunner/histogram-flux.sql
+++ b/src/mobu/templates/tapqueryrunner/histogram-flux.sql
@@ -1,4 +1,5 @@
-SELECT COUNT(*), FLOOR(LOG10(i_base_PsfFlux_instFlux)) as BIN
+SELECT 'monkey', 'histogram-flux',
+COUNT(*), FLOOR(LOG10(i_base_PsfFlux_instFlux)) as BIN
 FROM dp01_dc2_catalogs.forced_photometry
 GROUP BY BIN
 ORDER BY BIN

--- a/src/mobu/templates/tapqueryrunner/histogram-magnitude.sql
+++ b/src/mobu/templates/tapqueryrunner/histogram-magnitude.sql
@@ -1,4 +1,4 @@
-SELECT COUNT(*), FLOOR(object.mag_r) as BIN
+SELECT 'monkey', 'histogram-magnitude', COUNT(*), FLOOR(object.mag_r) as BIN
 FROM dp01_dc2_catalogs.object AS object
 JOIN dp01_dc2_catalogs.truth_match AS truth
 ON object.objectId = truth.match_objectId

--- a/src/mobu/templates/tapqueryrunner/neighbor-near.sql
+++ b/src/mobu/templates/tapqueryrunner/neighbor-near.sql
@@ -1,4 +1,4 @@
-SELECT 'monkey', o1.objectId AS id1, o2.objectId AS id2,
+SELECT 'monkey', 'neighbor-near', o1.objectId AS id1, o2.objectId AS id2,
 DISTANCE(POINT('ICRS', o1.ra, o1.dec), POINT('ICRS', o2.ra, o2.dec)) AS d
 FROM dp01_dc2_catalogs.object o1, dp01_dc2_catalogs.object o2
 WHERE CONTAINS(POINT('ICRS', o1.ra, o1.dec), CIRCLE('ICRS', {{ ra }}, {{ dec }}, {{ radius_near }}))=1

--- a/src/mobu/templates/tapqueryrunner/object-one.sql
+++ b/src/mobu/templates/tapqueryrunner/object-one.sql
@@ -1,3 +1,3 @@
-SELECT 'monkey', *
+SELECT 'monkey', 'object-one', *
 FROM dp01_dc2_catalogs.object
 WHERE objectId = {{ object }}

--- a/src/mobu/templates/tapqueryrunner/object-photometry.sql
+++ b/src/mobu/templates/tapqueryrunner/object-photometry.sql
@@ -1,4 +1,4 @@
-SELECT 'monkey', *
+SELECT 'monkey', 'object-photometry', *
 FROM dp01_dc2_catalogs.object AS o
 JOIN dp01_dc2_catalogs.forced_photometry AS fp
 ON o.objectId = fp.objectId

--- a/src/mobu/templates/tapqueryrunner/object-reference.sql
+++ b/src/mobu/templates/tapqueryrunner/object-reference.sql
@@ -1,4 +1,4 @@
-SELECT 'monkey', *
+SELECT 'monkey', 'object-reference', *
 FROM dp01_dc2_catalogs.object AS o
 JOIN dp01_dc2_catalogs.reference AS r
 ON o.objectId = r.objectId

--- a/src/mobu/templates/tapqueryrunner/object-several.sql
+++ b/src/mobu/templates/tapqueryrunner/object-several.sql
@@ -1,3 +1,3 @@
-SELECT 'monkey', *
+SELECT 'monkey', 'object-several', *
 FROM dp01_dc2_catalogs.object
 WHERE objectId IN ({{ objects }})

--- a/src/mobu/templates/tapqueryrunner/polygon-object.sql
+++ b/src/mobu/templates/tapqueryrunner/polygon-object.sql
@@ -1,3 +1,3 @@
-SELECT 'monkey', *
+SELECT 'monkey', 'polygon-object', *
 FROM dp01_dc2_catalogs.object
 WHERE CONTAINS(POINT('ICRS', ra, dec), POLYGON('ICRS', {{ polygon }}))=1

--- a/src/mobu/templates/tapqueryrunner/polygon-position.sql
+++ b/src/mobu/templates/tapqueryrunner/polygon-position.sql
@@ -1,3 +1,3 @@
-SELECT 'monkey', *
+SELECT 'monkey', 'polygon-position', *
 FROM dp01_dc2_catalogs.position
 WHERE CONTAINS(POINT('ICRS', coord_ra, coord_dec), POLYGON('ICRS', {{ polygon }}))=1

--- a/src/mobu/templates/tapqueryrunner/scan-flux.sql
+++ b/src/mobu/templates/tapqueryrunner/scan-flux.sql
@@ -1,3 +1,4 @@
-SELECT 'monkey', objectId, coord_ra, coord_dec, i_base_PsfFlux_instFlux
+SELECT 'monkey', 'scan-flux',
+objectId, coord_ra, coord_dec, i_base_PsfFlux_instFlux
 FROM dp01_dc2_catalogs.forced_photometry
 WHERE i_base_PsfFlux_instFlux BETWEEN {{ min_flux }} AND {{ max_flux }}

--- a/src/mobu/templates/tapqueryrunner/scan-magnitude.sql
+++ b/src/mobu/templates/tapqueryrunner/scan-magnitude.sql
@@ -1,4 +1,6 @@
-SELECT 'monkey', objectId, object.ra, object.dec, extendedness, object.mag_r, object.magerr_r, good
+SELECT 'monkey', 'scan-magnitude',
+objectId, object.ra, object.dec, extendedness, object.mag_r,
+object.magerr_r, good
 FROM dp01_dc2_catalogs.object AS object
 JOIN dp01_dc2_catalogs.truth_match AS truth
 ON object.objectId = truth.match_objectId

--- a/src/mobu/templates/tapqueryrunner/scan-top.sql
+++ b/src/mobu/templates/tapqueryrunner/scan-top.sql
@@ -1,4 +1,5 @@
-SELECT TOP 12 'monkey', objectId, ra, dec, extendedness, mag_r, magerr_r, good
+SELECT TOP 12 'monkey', 'scan-top',
+objectId, ra, dec, extendedness, mag_r, magerr_r, good
 FROM dp01_dc2_catalogs.object
 WHERE extendedness = 0 AND mag_r < 24
 ORDER by mag_r DESC


### PR DESCRIPTION
Add a static "monkey" string to each SELECT clause in the TAP
queries (previously, the histograms were missing one).  Add a
second static string specifying the query template to each query.

This makes it easier to generate statistics on the qserv side.