### PR TITLE
DM-38339: Update GitHub Actions configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,23 @@ name: CI
   pull_request: {}
 
 jobs:
+  lint:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+
   test:
+
     runs-on: ubuntu-latest
 
     strategy:
@@ -27,34 +43,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Run tox
+        uses: lsst-sqre/run-tox@v1
         with:
           python-version: ${{ matrix.python }}
-
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
-
-      - name: Install tox
-        run: pip install tox
-
-      - name: Cache tox environments
-        id: cache-tox
-        uses: actions/cache@v3
-        with:
-          path: .tox
-          # requirements/*.txt and pyproject.toml have versioning info
-          # that would impact the tox environment.
-          key: tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-${{ hashFiles('pyproject.toml') }}
-          restore-keys: |
-            tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-
-
-      - name: Run tox
-        run: tox -e py,coverage-report,typing
+          tox-envs: "py,coverage-report,typing"
 
   build:
+
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [lint, test]
 
     # Only do Docker builds of tagged releases and pull requests from ticket
     # branches.  This will still trigger on pull requests from untrusted
@@ -81,12 +79,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -100,7 +92,6 @@ jobs:
           context: .
           push: true
           tags: |
-            lsstsqre/mobu:${{ steps.vars.outputs.tag }}
             ghcr.io/lsst-sqre/mobu:${{ steps.vars.outputs.tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Use the new run-tox action and a separate lint step. Stop pushing containers to Docker Hub in favor of always using GitHub Container Registry.