### PR TITLE
DM-38339: Update to latest Safir, use Settings for config

### DIFF
--- a/src/mobu/business/base.py
+++ b/src/mobu/business/base.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import asyncio
 from asyncio import Queue, QueueEmpty
 from collections.abc import AsyncIterable, AsyncIterator
-from datetime import datetime, timezone
 from enum import Enum
 from typing import TypeVar
 
+from safir.datetime import current_datetime
 from structlog import BoundLogger
 
 from ..models.business import BusinessConfig, BusinessData
@@ -181,9 +181,9 @@ class Business:
         async def iter_next() -> T:
             return await iterator.__anext__()
 
-        start = datetime.now(tz=timezone.utc)
+        start = current_datetime(microseconds=True)
         while True:
-            now = datetime.now(tz=timezone.utc)
+            now = current_datetime(microseconds=True)
             remaining = timeout - (now - start).total_seconds()
             if remaining < 0:
                 break

--- a/src/mobu/business/tapqueryrunner.py
+++ b/src/mobu/business/tapqueryrunner.py
@@ -53,7 +53,9 @@ class TAPQueryRunner(Business):
 
     @staticmethod
     def _make_client(token: str) -> pyvo.dal.TAPService:
-        tap_url = config.environment_url + "/api/tap"
+        if not config.environment_url:
+            raise RuntimeError("environment_url not set")
+        tap_url = str(config.environment_url).rstrip("/") + "/api/tap"
 
         s = requests.Session()
         s.headers["Authorization"] = "Bearer " + token

--- a/src/mobu/cachemachine.py
+++ b/src/mobu/cachemachine.py
@@ -24,10 +24,12 @@ class CachemachineClient:
         self._session = session
         self._token = token
         self._username = username
+        if not config.environment_url:
+            raise RuntimeError("environment_url not set")
         self._url = (
-            config.environment_url
+            str(config.environment_url).rstrip("/")
             + "/cachemachine/jupyter/"
-            + config.cachemachine_image_policy
+            + config.cachemachine_image_policy.value
         )
 
     async def get_latest_weekly(self) -> JupyterImage:

--- a/src/mobu/config.py
+++ b/src/mobu/config.py
@@ -2,83 +2,102 @@
 
 from __future__ import annotations
 
-import os
-from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
 
-__all__ = ["Configuration", "config"]
+from pydantic import BaseSettings, Field, HttpUrl
+from safir.logging import LogLevel
+
+__all__ = [
+    "CachemachinePolicy",
+    "Configuration",
+    "config",
+]
 
 
-@dataclass
-class Configuration:
+class CachemachinePolicy(Enum):
+    """Policy for what eligible images to retrieve from cachemachine."""
+
+    available = "available"
+    desired = "desired"
+
+
+class Configuration(BaseSettings):
     """Configuration for mobu."""
 
-    alert_hook: str | None = os.getenv("ALERT_HOOK")
-    """The slack webhook used for alerting exceptions to slack.
-
-    Set with the ``ALERT_HOOK`` environment variable.
-    This is an https URL which should be considered secret.
-    If not set or set to "None", this feature will be disabled.
-    """
-
-    autostart: str | None = os.getenv("AUTOSTART")
-    """The path to a YAML file defining what flocks to automatically start.
-
-    The YAML file should, if given, be a list of flock specifications. All
-    flocks specified there will be automatically started when mobu starts.
-    """
-
-    environment_url: str = os.getenv("ENVIRONMENT_URL", "")
-    """The URL of the environment to run tests against.
-
-    This is used for creating URLs to services, such as JupyterHub.
-    mobu will not work if this is not set.
-
-    Set with the ``ENVIRONMENT_URL`` environment variable.
-    """
-
-    cachemachine_image_policy: str = os.getenv(
-        "CACHEMACHINE_IMAGE_POLICY", "available"
+    alert_hook: HttpUrl | None = Field(
+        None,
+        title="Slack webhook URL used for sending alerts",
+        description=(
+            "An https URL, which should be considered secret. If not set or"
+            " set to `None`, this feature will be disabled."
+        ),
+        env="ALERT_HOOK",
+        example="https://slack.example.com/ADFAW1452DAF41/",
     )
-    """Whether to use the images available on all nodes, or the images
-    desired by cachemachine.  In instances where image streaming is enabled,
-    and therefore pulls are fast, ``desired`` is preferred.  The default is
-    ``available``.
 
-    Set with the ``CACHEMACHINE_IMAGE_POLICY`` environment variable.
-    """
+    autostart: Path | None = Field(
+        None,
+        title="Path to YAML file defining flocks to automatically start",
+        description=(
+            "If given, the YAML file must contain a list of flock"
+            " specifications. All flocks given there will be automatically"
+            " started when mobu starts."
+        ),
+        env="AUTOSTART",
+        example="/etc/mobu/autostart.yaml",
+    )
 
-    gafaelfawr_token: str | None = os.getenv("GAFAELFAWR_TOKEN")
-    """The Gafaelfawr admin token to use to create user tokens.
+    environment_url: HttpUrl | None = Field(
+        None,
+        title="Base URL of the Science Platform environment",
+        description=(
+            "Used to create URLs to other services, such as Gafaelfawr and"
+            " JupyterHub. This is only optional to make writing the test"
+            " suite easier. If it is not set to a valid URL, mobu will abort"
+            " during startup."
+        ),
+        env="ENVIRONMENT_URL",
+        example="https://data.example.org/",
+    )
 
-    This token is used to make an admin API call to Gafaelfawr to get a token
-    for the user.  mobu will not work if this is not set.
+    cachemachine_image_policy: CachemachinePolicy = Field(
+        CachemachinePolicy.available,
+        field="Class of cachemachine images to use",
+        description=(
+            "Whether to use the images available on all nodes, or the images"
+            " desired by cachemachine. In instances where image streaming is"
+            " enabled and therefore pulls are fast, ``desired`` is preferred."
+            " The default is ``available``."
+        ),
+        env="CACHEMACHINE_IMAGE_POLICY",
+        example=CachemachinePolicy.desired,
+    )
 
-    Set with the ``GAFAELFAWR_TOKEN`` environment variable.
-    """
+    gafaelfawr_token: str | None = Field(
+        None,
+        field="Gafaelfawr admin token used to create user tokens",
+        description=(
+            "This token is used to make an admin API call to Gafaelfawr to"
+            " get a token for the user. This is only optional to make writing"
+            " tests easier. mobu will abort during startup if it is not set."
+        ),
+        env="GAFAELFAWR_TOKEN",
+        example="gt-vilSCi1ifK_MyuaQgMD2dQ.d6SIJhowv5Hs3GvujOyUig",
+    )
 
-    name: str = os.getenv("SAFIR_NAME", "mobu")
-    """The application's name, which doubles as the root HTTP endpoint path.
+    name: str = Field(
+        "mobu",
+        title="Name of application",
+        description="Doubles as the root HTTP endpoint path.",
+        env="SAFIR_NAME",
+    )
 
-    Set with the ``SAFIR_NAME`` environment variable.
-    """
-
-    profile: str = os.getenv("SAFIR_PROFILE", "development")
-    """Application run profile: "development" or "production".
-
-    Set with the ``SAFIR_PROFILE`` environment variable.
-    """
-
-    logger_name: str = os.getenv("SAFIR_LOGGER", "mobu")
-    """The root name of the application's logger.
-
-    Set with the ``SAFIR_LOGGER`` environment variable.
-    """
-
-    log_level: str = os.getenv("SAFIR_LOG_LEVEL", "INFO")
-    """The log level of the application's logger.
-
-    Set with the ``SAFIR_LOG_LEVEL`` environment variable.
-    """
+    log_level: LogLevel = Field(
+        LogLevel.INFO,
+        title="Log level of the application's logger",
+        env="SAFIR_LOG_LEVEL",
+    )
 
 
 config = Configuration()

--- a/src/mobu/config.py
+++ b/src/mobu/config.py
@@ -6,7 +6,7 @@ from enum import Enum
 from pathlib import Path
 
 from pydantic import BaseSettings, Field, HttpUrl
-from safir.logging import LogLevel
+from safir.logging import LogLevel, Profile
 
 __all__ = [
     "CachemachinePolicy",
@@ -91,6 +91,12 @@ class Configuration(BaseSettings):
         title="Name of application",
         description="Doubles as the root HTTP endpoint path.",
         env="SAFIR_NAME",
+    )
+
+    profile: Profile = Field(
+        Profile.development,
+        title="Application logging profile",
+        env="SAFIR_PROFILE",
     )
 
     log_level: LogLevel = Field(

--- a/src/mobu/constants.py
+++ b/src/mobu/constants.py
@@ -1,8 +1,5 @@
 """Global constants for mobu."""
 
-DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
-"""Date format to use for dates in Slack alerts."""
-
 NOTEBOOK_REPO_URL = "https://github.com/lsst-sqre/notebook-demo.git"
 """Default notebook repository for NotebookRunner."""
 

--- a/src/mobu/flock.py
+++ b/src/mobu/flock.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import math
-from datetime import datetime, timezone
-from typing import Dict, List, Optional
+from datetime import datetime
+from typing import Optional
 
 from aiohttp import ClientSession
 from aiojobs import Scheduler
+from safir.datetime import current_datetime
 
 from .business.base import Business
 from .business.jupyterjitterloginloop import JupyterJitterLoginLoop
@@ -46,7 +47,7 @@ class Flock:
         self._config = flock_config
         self._scheduler = scheduler
         self._session = session
-        self._monkeys: Dict[str, Monkey] = {}
+        self._monkeys: dict[str, Monkey] = {}
         self._start_time: Optional[datetime] = None
         try:
             self._business_type = _BUSINESS_CLASS[self._config.business]
@@ -68,7 +69,7 @@ class Flock:
             raise MonkeyNotFoundException(name)
         return monkey
 
-    def list_monkeys(self) -> List[str]:
+    def list_monkeys(self) -> list[str]:
         """List the names of the monkeys."""
         return sorted(self._monkeys.keys())
 
@@ -97,7 +98,7 @@ class Flock:
             monkey = self._create_monkey(user)
             self._monkeys[user.username] = monkey
             await monkey.start(self._scheduler)
-        self._start_time = datetime.now(tz=timezone.utc)
+        self._start_time = current_datetime(microseconds=True)
 
     async def stop(self) -> None:
         """Stop all the monkeys.
@@ -114,7 +115,7 @@ class Flock:
         config = self._config.monkey_config(user.username)
         return Monkey(config, self._business_type, user, self._session)
 
-    async def _create_users(self) -> List[AuthenticatedUser]:
+    async def _create_users(self) -> list[AuthenticatedUser]:
         """Create the authenticated users the monkeys will run as."""
         users = self._config.users
         if not users:
@@ -127,7 +128,7 @@ class Flock:
             for u in users
         ]
 
-    def _users_from_spec(self, spec: UserSpec, count: int) -> List[User]:
+    def _users_from_spec(self, spec: UserSpec, count: int) -> list[User]:
         """Generate count Users from the provided spec."""
         padding = int(math.log10(count) + 1)
         users = []

--- a/src/mobu/handlers/external.py
+++ b/src/mobu/handlers/external.py
@@ -1,12 +1,12 @@
 """Handlers for the app's external root, ``/mobu/``."""
 
 import json
-from datetime import datetime
-from typing import Any, List
+from typing import Any
 from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, Response
 from fastapi.responses import FileResponse, JSONResponse
+from safir.datetime import current_datetime
 from safir.dependencies.gafaelfawr import auth_logger_dependency
 from safir.metadata import get_metadata
 from safir.models import ErrorModel
@@ -78,11 +78,11 @@ async def get_index() -> Index:
 
 
 @external_router.get(
-    "/flocks", response_model=List[str], summary="List running flocks"
+    "/flocks", response_model=list[str], summary="List running flocks"
 )
 async def get_flocks(
     manager: MonkeyBusinessManager = Depends(monkey_business_manager),
-) -> List[str]:
+) -> list[str]:
     return manager.list_flocks()
 
 
@@ -143,14 +143,14 @@ async def delete_flock(
 @external_router.get(
     "/flocks/{flock}/monkeys",
     response_class=FormattedJSONResponse,
-    response_model=List[str],
+    response_model=list[str],
     responses={404: {"description": "Flock not found", "model": ErrorModel}},
     summary="Monkeys in flock",
 )
 async def get_monkeys(
     flock: str,
     manager: MonkeyBusinessManager = Depends(monkey_business_manager),
-) -> List[str]:
+) -> list[str]:
     return manager.get_flock(flock).list_monkeys()
 
 
@@ -190,7 +190,7 @@ async def get_monkey_log(
     return FileResponse(
         path=manager.get_flock(flock).get_monkey(monkey).logfile(),
         media_type="text/plain",
-        filename=f"{flock}-{monkey}-{datetime.now()}",
+        filename=f"{flock}-{monkey}-{current_datetime()}",
     )
 
 
@@ -211,10 +211,10 @@ async def get_flock_summary(
 @external_router.get(
     "/summary",
     response_class=FormattedJSONResponse,
-    response_model=List[FlockSummary],
+    response_model=list[FlockSummary],
     summary="Summary of statistics for all flocks",
 )
 async def get_summary(
     manager: MonkeyBusinessManager = Depends(monkey_business_manager),
-) -> List[FlockSummary]:
+) -> list[FlockSummary]:
     return manager.summarize_flocks()

--- a/src/mobu/jupyterclient.py
+++ b/src/mobu/jupyterclient.py
@@ -13,7 +13,6 @@ import re
 import string
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from functools import wraps
 from http.cookies import BaseCookie
 from typing import Any, Optional, TypeVar, cast
@@ -28,6 +27,7 @@ from aiohttp import (
     TCPConnector,
 )
 from aiohttp.client import _RequestContextManager, _WSRequestContextManager
+from safir.datetime import current_datetime
 from structlog import BoundLogger
 
 from .cachemachine import CachemachineClient
@@ -87,7 +87,7 @@ class JupyterSpawnProgress:
     def __init__(self, response: ClientResponse, logger: BoundLogger) -> None:
         self._response = response
         self._logger = logger
-        self._start = datetime.now(tz=timezone.utc)
+        self._start = current_datetime(microseconds=True)
 
     async def __aiter__(self) -> AsyncIterator[ProgressMessage]:
         """Iterate over spawn progress events."""
@@ -110,7 +110,7 @@ class JupyterSpawnProgress:
                 continue
 
             # Log the event and yield it.
-            now = datetime.now(tz=timezone.utc)
+            now = current_datetime(microseconds=True)
             elapsed = int((now - self._start).total_seconds())
             if event.ready:
                 status = "complete"

--- a/src/mobu/jupyterclient.py
+++ b/src/mobu/jupyterclient.py
@@ -222,7 +222,11 @@ class JupyterClient:
         self.user = user
         self.log = log
         self.config = jupyter_config
-        self.jupyter_url = config.environment_url + jupyter_config.url_prefix
+        if not config.environment_url:
+            raise RuntimeError("environment_url not set")
+        self.jupyter_url = (
+            str(config.environment_url).rstrip("/") + jupyter_config.url_prefix
+        )
 
         xsrftoken = "".join(
             random.choices(string.ascii_uppercase + string.digits, k=16)

--- a/src/mobu/main.py
+++ b/src/mobu/main.py
@@ -12,7 +12,7 @@ from importlib.metadata import metadata, version
 
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
-from safir.logging import Profile, configure_logging, configure_uvicorn_logging
+from safir.logging import configure_logging, configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
 
 from .autostart import autostart
@@ -28,7 +28,7 @@ __all__ = ["app", "config"]
 
 
 configure_logging(
-    profile=Profile.production, log_level=config.log_level, name="mobu"
+    profile=config.profile, log_level=config.log_level, name="mobu"
 )
 configure_uvicorn_logging(config.log_level)
 

--- a/src/mobu/main.py
+++ b/src/mobu/main.py
@@ -12,7 +12,7 @@ from importlib.metadata import metadata, version
 
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
-from safir.logging import configure_logging
+from safir.logging import Profile, configure_logging, configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
 
 from .autostart import autostart
@@ -28,10 +28,9 @@ __all__ = ["app", "config"]
 
 
 configure_logging(
-    profile=config.profile,
-    log_level=config.log_level,
-    name=config.logger_name,
+    profile=Profile.production, log_level=config.log_level, name="mobu"
 )
+configure_uvicorn_logging(config.log_level)
 
 app = FastAPI(
     title="mobu",

--- a/src/mobu/main.py
+++ b/src/mobu/main.py
@@ -14,6 +14,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
 from safir.logging import configure_logging, configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
+from safir.models import ErrorLocation
 
 from .autostart import autostart
 from .config import config
@@ -81,7 +82,7 @@ async def flock_not_found_exception_handler(
         content={
             "detail": [
                 {
-                    "loc": ["path", "flock"],
+                    "loc": [ErrorLocation.path, "flock"],
                     "msg": f"Flock for {exc.flock} not found",
                     "type": "flock_not_found",
                 }
@@ -99,7 +100,7 @@ async def monkey_not_found_exception_handler(
         content={
             "detail": [
                 {
-                    "loc": ["path", "monkey"],
+                    "loc": [ErrorLocation.path, "monkey"],
                     "msg": f"Monkey for {exc.monkey} not found",
                     "type": "monkey_not_found",
                 }

--- a/src/mobu/main.py
+++ b/src/mobu/main.py
@@ -55,6 +55,8 @@ app.add_middleware(XForwardedMiddleware)
 async def startup_event() -> None:
     if not config.environment_url:
         raise RuntimeError("ENVIRONMENT_URL was not set")
+    if not config.gafaelfawr_token:
+        raise RuntimeError("GAFAELFAWR_TOKEN was not set")
     await monkey_business_manager.init()
     if config.autostart:
         await autostart()

--- a/src/mobu/main.py
+++ b/src/mobu/main.py
@@ -12,7 +12,7 @@ from importlib.metadata import metadata, version
 
 from fastapi import FastAPI, Request, status
 from fastapi.responses import JSONResponse
-from safir.logging import configure_logging, configure_uvicorn_logging
+from safir.logging import Profile, configure_logging, configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
 from safir.models import ErrorLocation
 
@@ -31,7 +31,8 @@ __all__ = ["app", "config"]
 configure_logging(
     profile=config.profile, log_level=config.log_level, name="mobu"
 )
-configure_uvicorn_logging(config.log_level)
+if config.profile == Profile.production:
+    configure_uvicorn_logging(config.log_level)
 
 app = FastAPI(
     title="mobu",

--- a/src/mobu/models/user.py
+++ b/src/mobu/models/user.py
@@ -95,7 +95,11 @@ class AuthenticatedUser(User):
     async def create(
         cls, user: User, scopes: list[str], session: ClientSession
     ) -> Self:
-        token_url = f"{config.environment_url}/auth/api/v1/tokens"
+        if not config.environment_url:
+            raise RuntimeError("environment_url not set")
+        token_url = (
+            str(config.environment_url).rstrip("/") + "/auth/api/v1/tokens"
+        )
         data: dict[str, Any] = {
             "username": user.username,
             "name": "Mobu Test User",

--- a/src/mobu/status.py
+++ b/src/mobu/status.py
@@ -52,6 +52,6 @@ async def post_status() -> None:
         )
         text += line
 
-    logger = structlog.get_logger(config.logger_name)
+    logger = structlog.get_logger("mobu")
     slack = SlackWebhookClient(config.alert_hook, "Mobu", logger)
     await slack.post(SlackMessage(message=text))

--- a/src/mobu/timings.py
+++ b/src/mobu/timings.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from types import TracebackType
 from typing import Literal, Optional
+
+from safir.datetime import current_datetime
 
 from .exceptions import MobuSlackException
 from .models.timings import StopwatchData
@@ -73,7 +75,7 @@ class Stopwatch:
     ) -> None:
         self.event = event
         self.annotations = annotations
-        self.start_time = datetime.now(tz=timezone.utc)
+        self.start_time = current_datetime(microseconds=True)
         self.stop_time: Optional[datetime] = None
         self.failed = False
         self._previous = previous
@@ -87,7 +89,7 @@ class Stopwatch:
         exc_val: Exception | None,
         exc_tb: TracebackType | None,
     ) -> Literal[False]:
-        self.stop_time = datetime.now(tz=timezone.utc)
+        self.stop_time = current_datetime(microseconds=True)
         if exc_val:
             self.failed = True
         if exc_val and isinstance(exc_val, MobuSlackException):
@@ -102,7 +104,7 @@ class Stopwatch:
         if self.stop_time:
             return self.stop_time - self.start_time
         else:
-            return datetime.now(tz=timezone.utc) - self.start_time
+            return current_datetime(microseconds=True) - self.start_time
 
     def dump(self) -> StopwatchData:
         """Convert to a Pydantic model."""

--- a/tests/autostart_test.py
+++ b/tests/autostart_test.py
@@ -46,9 +46,8 @@ def configure_autostart(
 ) -> Iterator[None]:
     """Set up the autostart configuration."""
     mock_gafaelfawr(mock_aioresponses, any_uid=True)
-    autostart_path = tmp_path / "autostart.yaml"
-    autostart_path.write_text(AUTOSTART_CONFIG)
-    config.autostart = str(autostart_path)
+    config.autostart = tmp_path / "autostart.yaml"
+    config.autostart.write_text(AUTOSTART_CONFIG)
     yield
     config.autostart = None
 

--- a/tests/business/jupyterloginloop_test.py
+++ b/tests/business/jupyterloginloop_test.py
@@ -423,7 +423,7 @@ async def test_spawn_failed(
         }
     ]
     log = slack.messages[0]["blocks"][2]["text"]["text"]
-    log = re.sub(r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d", "<ts>", log)
+    log = re.sub(r"\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(.\d\d\d)?", "<ts>", log)
     assert log == (
         "*Log*\n"
         "<ts> - Server requested\n"

--- a/tests/business/jupyterloginloop_test.py
+++ b/tests/business/jupyterloginloop_test.py
@@ -172,7 +172,8 @@ async def test_alert(
     assert data["business"]["failure_count"] > 0
 
     # Check that an appropriate error was posted.
-    url = urljoin(config.environment_url, "/nb/hub/spawn")
+    assert config.environment_url
+    url = urljoin(str(config.environment_url), "/nb/hub/spawn")
     assert slack.messages == [
         {
             "blocks": [
@@ -246,8 +247,10 @@ async def test_redirect_loop(
     assert data["business"]["failure_count"] > 0
 
     # Check that an appropriate error was posted.
+    assert config.environment_url
     url = urljoin(
-        config.environment_url, "/nb/hub/api/users/testuser1/server/progress"
+        str(config.environment_url),
+        "/nb/hub/api/users/testuser1/server/progress",
     )
     assert slack.messages == [
         {

--- a/tests/monkeyflocker_test.py
+++ b/tests/monkeyflocker_test.py
@@ -2,14 +2,8 @@
 
 from __future__ import annotations
 
-import errno
 import json
-import logging
-import os
 import shutil
-import socket
-import subprocess
-import time
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -18,53 +12,12 @@ from unittest.mock import ANY
 import httpx
 import pytest
 from click.testing import CliRunner
+from safir.testing.uvicorn import UvicornProcess, spawn_uvicorn
 
 from mobu.config import config
 from monkeyflocker.cli import main
 
 from .support.gafaelfawr import make_gafaelfawr_token
-
-APP_SOURCE = """
-from collections.abc import Awaitable, Callable
-
-from aioresponses import aioresponses
-from fastapi import FastAPI, Request, Response
-from starlette.middleware.base import BaseHTTPMiddleware
-
-from mobu.config import config
-from mobu.main import app
-from tests.support.gafaelfawr import mock_gafaelfawr
-from tests.support.jupyter import mock_jupyter
-
-
-# Pretend Gafaelfawr is doing authentication in front of mobu.  This is a
-# total hack based on https://github.com/tiangolo/fastapi/issues/2727 that
-# adds the header that would have been added by Gafaelfawr.  Unfortunately,
-# there's no documented way to modify request headers in middleware, so we
-# have to muck about with internals.
-class AddAuthHeaderMiddleware(BaseHTTPMiddleware):
-    async def dispatch(
-        self,
-        request: Request,
-        call_next: Callable[[Request], Awaitable[Response]],
-    ) -> Response:
-        request.headers.__dict__["_list"].append(
-            (b"x-auth-request-user", b"someuser")
-        )
-        return await call_next(request)
-
-
-# Add the new middleware.
-app.add_middleware(AddAuthHeaderMiddleware)
-
-
-@app.on_event("startup")
-async def startup_event() -> None:
-    mocked = aioresponses()
-    mocked.start()
-    mock_gafaelfawr(mocked)
-    mock_jupyter(mocked)
-"""
 
 FLOCK_CONFIG = """
 name: basic
@@ -76,64 +29,27 @@ business: Business
 """
 
 
-def _wait_for_server(port: int, timeout: float = 5.0) -> None:
-    """Wait until a server accepts connections on the specified port."""
-    deadline = time.time() + timeout
-    while True:
-        socket_timeout = deadline - time.time()
-        if socket_timeout < 0.0:
-            assert False, f"Server did not start on port {port} in {timeout}s"
-        try:
-            s = socket.socket()
-            s.settimeout(socket_timeout)
-            s.connect(("localhost", port))
-        except socket.timeout:
-            pass
-        except socket.error as e:
-            if e.errno not in [errno.ETIMEDOUT, errno.ECONNREFUSED]:
-                raise
-        else:
-            s.close()
-            return
-        time.sleep(0.1)
-
-
 @pytest.fixture
-def app_url(tmp_path: Path) -> Iterator[str]:
+def monkeyflocker_app(tmp_path: Path) -> Iterator[UvicornProcess]:
     """Run the application as a separate process for monkeyflocker access."""
-    app_path = tmp_path / "testing.py"
-    app_path.write_text(APP_SOURCE)
-
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("127.0.0.1", 0))
-    port = s.getsockname()[1]
-
-    cmd = ["uvicorn", "--fd", "0", "testing:app"]
-    logging.info("Starting server with command %s", " ".join(cmd))
     assert config.environment_url
-    p = subprocess.Popen(
-        cmd,
-        cwd=str(tmp_path),
-        stdin=s.fileno(),
+    config.gafaelfawr_token = make_gafaelfawr_token()
+    uvicorn = spawn_uvicorn(
+        working_directory=tmp_path,
+        factory="tests.support.monkeyflocker:create_app",
         env={
-            **os.environ,
-            "ENVIRONMENT_URL": config.environment_url,
-            "GAFAELFAWR_TOKEN": make_gafaelfawr_token(),
-            "PYTHONPATH": os.getcwd(),
+            "ENVIRONMENT_URL": str(config.environment_url),
+            "GAFAELFAWR_TOKEN": config.gafaelfawr_token,
         },
     )
-    s.close()
-
-    logging.info("Waiting for server to start")
-    _wait_for_server(port)
-
-    try:
-        yield f"http://localhost:{port}"
-    finally:
-        p.terminate()
+    yield uvicorn
+    config.gafaelfawr_token = None
+    uvicorn.process.terminate()
 
 
-def test_start_report_stop(tmp_path: Path, app_url: str) -> None:
+def test_start_report_stop(
+    tmp_path: Path, monkeyflocker_app: UvicornProcess
+) -> None:
     runner = CliRunner()
     spec_path = tmp_path / "spec.yaml"
     spec_path.write_text(FLOCK_CONFIG)
@@ -145,7 +61,7 @@ def test_start_report_stop(tmp_path: Path, app_url: str) -> None:
         [
             "start",
             "-e",
-            app_url,
+            monkeyflocker_app.url,
             "-f",
             str(spec_path),
             "-k",
@@ -183,7 +99,7 @@ def test_start_report_stop(tmp_path: Path, app_url: str) -> None:
             },
         ],
     }
-    r = httpx.get(f"{app_url}/mobu/flocks/basic")
+    r = httpx.get(f"{monkeyflocker_app.url}/mobu/flocks/basic")
     assert r.status_code == 200
     assert r.json() == expected
 
@@ -192,7 +108,7 @@ def test_start_report_stop(tmp_path: Path, app_url: str) -> None:
         [
             "report",
             "-e",
-            app_url,
+            monkeyflocker_app.url,
             "-o",
             str(output_path),
             "-k",
@@ -213,7 +129,7 @@ def test_start_report_stop(tmp_path: Path, app_url: str) -> None:
         [
             "stop",
             "-e",
-            app_url,
+            monkeyflocker_app.url,
             "-o",
             str(output_path),
             "-k",
@@ -228,5 +144,5 @@ def test_start_report_stop(tmp_path: Path, app_url: str) -> None:
     log = (output_path / "testuser1_log.txt").read_text()
     assert "Idling..." in log
 
-    r = httpx.get(f"{app_url}/mobu/flocks/basic")
+    r = httpx.get(f"{monkeyflocker_app.url}/mobu/flocks/basic")
     assert r.status_code == 404

--- a/tests/support/gafaelfawr.py
+++ b/tests/support/gafaelfawr.py
@@ -71,7 +71,7 @@ def mock_gafaelfawr(
         response = {"token": make_gafaelfawr_token(kwargs["json"]["username"])}
         return CallbackResult(payload=response, status=200)
 
-    base_url = config.environment_url
+    base_url = str(config.environment_url).rstrip("/")
     mocked.post(
         f"{base_url}/auth/api/v1/tokens", callback=handler, repeat=True
     )

--- a/tests/support/jupyter.py
+++ b/tests/support/jupyter.py
@@ -7,7 +7,7 @@ import json
 import re
 from base64 import urlsafe_b64decode
 from contextlib import redirect_stdout
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from enum import Enum
 from io import StringIO
 from re import Pattern
@@ -19,6 +19,7 @@ from uuid import uuid4
 from aiohttp import ClientWebSocketResponse, RequestInfo, TooManyRedirects
 from aioresponses import CallbackResult, aioresponses
 from multidict import CIMultiDict, CIMultiDictProxy
+from safir.datetime import current_datetime
 from yarl import URL
 
 from mobu.business.jupyterpythonloop import _GET_NODE
@@ -98,7 +99,7 @@ class MockJupyter:
             body = {"name": user, "servers": {"": server}}
         elif state == JupyterState.LAB_RUNNING:
             delete_at = self._delete_at.get(user)
-            if delete_at and datetime.now(tz=timezone.utc) > delete_at:
+            if delete_at and current_datetime(microseconds=True) > delete_at:
                 del self._delete_at[user]
                 self.state[user] = JupyterState.LOGGED_IN
             if delete_at:
@@ -200,7 +201,7 @@ class MockJupyter:
         if self.delete_immediate:
             self.state[user] = JupyterState.LOGGED_IN
         else:
-            now = datetime.now(tz=timezone.utc)
+            now = current_datetime(microseconds=True)
             self._delete_at[user] = now + timedelta(seconds=5)
         return CallbackResult(status=202)
 

--- a/tests/support/jupyter.py
+++ b/tests/support/jupyter.py
@@ -50,10 +50,11 @@ class JupyterState(Enum):
 
 def _url(route: str, regex: bool = False) -> str | Pattern[str]:
     """Construct a URL for JupyterHub/Proxy."""
+    base_url = str(config.environment_url).rstrip("/")
     if not regex:
-        return f"{config.environment_url}/nb/{route}"
+        return f"{base_url}/nb/{route}"
 
-    prefix = re.escape(f"{config.environment_url}/nb/")
+    prefix = re.escape(f"{base_url}/nb/")
     return re.compile(prefix + route)
 
 

--- a/tests/support/monkeyflocker.py
+++ b/tests/support/monkeyflocker.py
@@ -1,0 +1,49 @@
+"""Create a version of the app for monkeyflocker testing."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from aioresponses import aioresponses
+from fastapi import FastAPI, Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from mobu.main import app
+
+from .gafaelfawr import mock_gafaelfawr
+from .jupyter import mock_jupyter
+
+
+class AddAuthHeaderMiddleware(BaseHTTPMiddleware):
+    """Mock running behind a Gafaelfawr-aware ingress.
+
+    Pretend Gafaelfawr is doing authentication in front of mobu.  This is a
+    total hack based on https://github.com/tiangolo/fastapi/issues/2727 that
+    adds the header that would have been added by Gafaelfawr.  Unfortunately,
+    there's no documented way to modify request headers in middleware, so we
+    have to muck about with internals.
+    """
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        request.headers.__dict__["_list"].append(
+            (b"x-auth-request-user", b"someuser")
+        )
+        return await call_next(request)
+
+
+def create_app() -> FastAPI:
+    """Configure the FastAPI app for monkeyflocker testing."""
+    app.add_middleware(AddAuthHeaderMiddleware)
+
+    @app.on_event("startup")
+    async def startup_event() -> None:
+        mocked = aioresponses()
+        mocked.start()
+        mock_gafaelfawr(mocked)
+        mock_jupyter(mocked)
+
+    return app

--- a/tests/timings_test.py
+++ b/tests/timings_test.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 
 import pytest
+from safir.datetime import current_datetime
 
 from mobu.models.timings import StopwatchData
 from mobu.timings import Timings
@@ -14,13 +15,14 @@ def test_timings() -> None:
     timings = Timings()
     assert timings.dump() == []
 
-    now = datetime.now(tz=timezone.utc)
+    now = current_datetime(microseconds=True)
     with timings.start("something") as sw:
         assert sw.event == "something"
         assert sw.annotations == {}
         assert now + timedelta(seconds=5) > sw.start_time >= now
         assert sw.stop_time is None
-        assert sw.elapsed <= datetime.now(tz=timezone.utc) - sw.start_time
+        elapsed = sw.elapsed
+        assert elapsed <= current_datetime(microseconds=True) - sw.start_time
         old_elapsed = sw.elapsed
 
     first_sw = sw


### PR DESCRIPTION
- Use `current_datetime` and `format_datetime_for_logging` from Safir
- Convert the configuration class to `Settings` and do more validation of input
- Update the logging configuration to use enums and also configure Uvicorn logging
- Use `spawn_uvicorn` to start a process for monkeyflocker testing