### PR TITLE
DM-38339: Use relative imports for test modules

### DIFF
--- a/tests/autostart_test.py
+++ b/tests/autostart_test.py
@@ -11,7 +11,8 @@ from aioresponses import aioresponses
 from httpx import AsyncClient
 
 from mobu.config import config
-from tests.support.gafaelfawr import mock_gafaelfawr
+
+from .support.gafaelfawr import mock_gafaelfawr
 
 AUTOSTART_CONFIG = """
 - name: basic

--- a/tests/business/jupyterloginloop_test.py
+++ b/tests/business/jupyterloginloop_test.py
@@ -12,9 +12,10 @@ from httpx import AsyncClient
 from safir.testing.slack import MockSlackWebhook
 
 from mobu.config import config
-from tests.support.gafaelfawr import mock_gafaelfawr
-from tests.support.jupyter import JupyterAction, JupyterState, MockJupyter
-from tests.support.util import wait_for_business
+
+from ..support.gafaelfawr import mock_gafaelfawr
+from ..support.jupyter import JupyterAction, JupyterState, MockJupyter
+from ..support.util import wait_for_business
 
 
 @pytest.mark.asyncio

--- a/tests/business/jupyterpythonloop_test.py
+++ b/tests/business/jupyterpythonloop_test.py
@@ -10,8 +10,8 @@ from aioresponses import aioresponses
 from httpx import AsyncClient
 from safir.testing.slack import MockSlackWebhook
 
-from tests.support.gafaelfawr import mock_gafaelfawr
-from tests.support.util import wait_for_business
+from ..support.gafaelfawr import mock_gafaelfawr
+from ..support.util import wait_for_business
 
 
 @pytest.mark.asyncio

--- a/tests/business/notebookrunner_test.py
+++ b/tests/business/notebookrunner_test.py
@@ -14,8 +14,8 @@ from git.util import Actor
 from httpx import AsyncClient
 from safir.testing.slack import MockSlackWebhook
 
-from tests.support.gafaelfawr import mock_gafaelfawr
-from tests.support.util import wait_for_business
+from ..support.gafaelfawr import mock_gafaelfawr
+from ..support.util import wait_for_business
 
 
 @pytest.mark.asyncio

--- a/tests/business/tapqueryrunner_test.py
+++ b/tests/business/tapqueryrunner_test.py
@@ -18,8 +18,9 @@ import mobu
 from mobu.business.tapqueryrunner import TAPQueryRunner
 from mobu.models.business import BusinessConfig
 from mobu.models.user import AuthenticatedUser
-from tests.support.gafaelfawr import mock_gafaelfawr
-from tests.support.util import wait_for_business
+
+from ..support.gafaelfawr import mock_gafaelfawr
+from ..support.util import wait_for_business
 
 
 @pytest.mark.asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,9 +20,10 @@ from safir.testing.slack import MockSlackWebhook, mock_slack_webhook
 
 from mobu import main
 from mobu.config import config
-from tests.support.cachemachine import MockCachemachine, mock_cachemachine
-from tests.support.gafaelfawr import make_gafaelfawr_token
-from tests.support.jupyter import (
+
+from .support.cachemachine import MockCachemachine, mock_cachemachine
+from .support.gafaelfawr import make_gafaelfawr_token
+from .support.jupyter import (
     MockJupyter,
     MockJupyterWebSocket,
     mock_jupyter,

--- a/tests/handlers/flock_test.py
+++ b/tests/handlers/flock_test.py
@@ -9,8 +9,8 @@ import pytest
 from aioresponses import aioresponses
 from httpx import AsyncClient
 
-from tests.support.gafaelfawr import mock_gafaelfawr
-from tests.support.util import wait_for_business
+from ..support.gafaelfawr import mock_gafaelfawr
+from ..support.util import wait_for_business
 
 
 @pytest.mark.asyncio

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -7,7 +7,8 @@ from aiohttp import ClientSession
 from aioresponses import aioresponses
 
 from mobu.models.user import AuthenticatedUser, User
-from tests.support.gafaelfawr import mock_gafaelfawr
+
+from .support.gafaelfawr import mock_gafaelfawr
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Following the use of relative imports for the main mobu code, also use relative imports for tests for the test support modules.