### PR TITLE
DM-38339: Remove types from docstrings

### DIFF
--- a/src/mobu/business/base.py
+++ b/src/mobu/business/base.py
@@ -47,12 +47,12 @@ class Business:
 
     Parameters
     ----------
-    logger : `structlog.BoundLogger`
+    logger
         Logger to use to report the results of business.
-    options : Dict[`str`, Any]
+    business_config
         Configuration options for the business.
-    token : `str`
-        The authentication token to use for internal calls.
+    user
+        User with their authentication token to use to run the business.
     """
 
     def __init__(

--- a/src/mobu/cachemachine.py
+++ b/src/mobu/cachemachine.py
@@ -37,7 +37,7 @@ class CachemachineClient:
 
         Returns
         -------
-        image : `mobu.models.jupyter.JupyterImage`
+        mobu.models.jupyter.JupyterImage
             The corresponding image.
 
         Raises
@@ -56,7 +56,7 @@ class CachemachineClient:
 
         Returns
         -------
-        image : `mobu.models.jupyter.JupyterImage`
+        mobu.models.jupyter.JupyterImage
             The corresponding image.
 
         Raises

--- a/src/mobu/handlers/external.py
+++ b/src/mobu/handlers/external.py
@@ -21,18 +21,6 @@ from ..models.flock import FlockConfig, FlockData, FlockSummary
 from ..models.index import Index
 from ..models.monkey import MonkeyData
 
-__all__ = [
-    "external_router",
-    "delete_flock",
-    "get_flock",
-    "get_flocks",
-    "get_index",
-    "get_monkey",
-    "get_monkeys",
-    "get_monkey_log",
-    "put_flock",
-]
-
 external_router = APIRouter()
 """FastAPI router for all external handlers."""
 
@@ -59,17 +47,6 @@ class FormattedJSONResponse(JSONResponse):
     summary="Application metadata",
 )
 async def get_index() -> Index:
-    """GET ``/mobu/`` (the app's external root).
-
-    Customize this handler to return whatever the top-level resource of your
-    application should return. For example, consider listing key API URLs.
-    When doing so, also change or customize the response model in
-    mobu.models.index.
-
-    By convention, the root of the external API includes a field called
-    ``metadata`` that provides the same Safir-generated metadata as the
-    internal root endpoint.
-    """
     metadata = get_metadata(
         package_name="mobu",
         application_name=config.name,

--- a/src/mobu/handlers/internal.py
+++ b/src/mobu/handlers/internal.py
@@ -30,10 +30,6 @@ internal_router = APIRouter()
     summary="Application metadata",
 )
 async def get_index() -> Metadata:
-    """GET ``/`` (the app's internal root).
-
-    By convention, this endpoint returns only the application's metadata.
-    """
     return get_metadata(
         package_name="mobu",
         application_name=config.name,

--- a/src/mobu/jupyterclient.py
+++ b/src/mobu/jupyterclient.py
@@ -132,9 +132,9 @@ class JupyterClientSession:
 
     Parameters
     ----------
-    session : `aiohttp.ClientSession`
+    session
         The session to wrap.
-    token : `str`
+    token
         The token to send.
 
     Notes
@@ -185,7 +185,7 @@ F = TypeVar("F", bound=Callable[..., Awaitable[Any]])
 
 
 def _convert_exception(f: F) -> F:
-    """Convert web errors to a `~mobu.exceptions.SlackError`."""
+    """Convert web errors to a `~mobu.exceptions.MobuSlackException`."""
 
     @wraps(f)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
@@ -194,7 +194,7 @@ def _convert_exception(f: F) -> F:
         except ClientResponseError as e:
             obj = args[0]
             username = obj.user.username
-            raise JupyterResponseError.from_exception(username, e) from None
+            raise JupyterResponseError.from_exception(username, e) from e
         except (ClientError, ConnectionResetError, asyncio.TimeoutError) as e:
             obj = args[0]
             username = obj.user.username
@@ -272,7 +272,7 @@ class JupyterClient:
 
         Parameters
         ----------
-        final : `bool`
+        final
             The last attempt, so log some additional information if the lab
             still isn't gone.
         """

--- a/src/mobu/timings.py
+++ b/src/mobu/timings.py
@@ -58,11 +58,11 @@ class Stopwatch:
 
     Parameters
     ----------
-    event : `str`
+    event
         The name of the event.
-    annotation : Dict[`str`, Any], optional
+    annotation
         Arbitrary annotations.
-    previous : `Stopwatch`, optional
+    previous
         The previous stopwatch, used to calculate the idle time between
         timed events.
     """

--- a/src/mobu/util.py
+++ b/src/mobu/util.py
@@ -9,7 +9,7 @@ from typing import TypeVar
 
 T = TypeVar("T")
 
-__all__ = ["wait_first"]
+__all__ = ["schedule_periodic", "wait_first"]
 
 
 def schedule_periodic(


### PR DESCRIPTION
Take advantage of Sphinx's new support for type annotations and remove type information from docstrings except for the return value, which now doesn't need a variable name.

Remove docstrings from routes, and remove __all__ in the handler module since we won't generate documentation for that (even if we get around to generating documentation).