### PR TITLE
DM-38339: Redo monkey logging and state machine

### DIFF
--- a/src/mobu/business/base.py
+++ b/src/mobu/business/base.py
@@ -9,7 +9,7 @@ from enum import Enum
 from typing import TypeVar
 
 from safir.datetime import current_datetime
-from structlog import BoundLogger
+from structlog.stdlib import BoundLogger
 
 from ..models.business import BusinessConfig, BusinessData
 from ..models.user import AuthenticatedUser
@@ -132,10 +132,10 @@ class Business:
     async def stop(self) -> None:
         """Tell the running background task to stop and wait for that."""
         self.stopping = True
+        self.logger.info("Stopping...")
         await self.control.put(BusinessCommand.STOP)
         await self.control.join()
         self.logger.info("Stopped")
-        await self.close()
 
     async def pause(self, seconds: float) -> None:
         """Pause for up to the number of seconds, handling commands."""

--- a/src/mobu/business/jupyterloginloop.py
+++ b/src/mobu/business/jupyterloginloop.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 from aiohttp import ClientError, ClientResponseError
 from safir.datetime import current_datetime, format_datetime_for_logging
-from structlog import BoundLogger
+from structlog.stdlib import BoundLogger
 
 from ..exceptions import (
     JupyterResponseError,

--- a/src/mobu/business/jupyterpythonloop.py
+++ b/src/mobu/business/jupyterpythonloop.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from structlog import BoundLogger
+from structlog.stdlib import BoundLogger
 
 from ..jupyterclient import JupyterLabSession
 from ..models.business import BusinessConfig

--- a/src/mobu/business/notebookrunner.py
+++ b/src/mobu/business/notebookrunner.py
@@ -13,7 +13,7 @@ from tempfile import TemporaryDirectory
 from typing import Any, Optional
 
 from git.repo import Repo
-from structlog import BoundLogger
+from structlog.stdlib import BoundLogger
 
 from ..exceptions import NotebookRepositoryError
 from ..jupyterclient import JupyterLabSession

--- a/src/mobu/business/tapqueryrunner.py
+++ b/src/mobu/business/tapqueryrunner.py
@@ -14,7 +14,7 @@ import pyvo
 import requests
 import shortuuid
 import yaml
-from structlog import BoundLogger
+from structlog.stdlib import BoundLogger
 
 from ..config import config
 from ..exceptions import CodeExecutionError

--- a/src/mobu/jupyterclient.py
+++ b/src/mobu/jupyterclient.py
@@ -28,7 +28,7 @@ from aiohttp import (
 )
 from aiohttp.client import _RequestContextManager, _WSRequestContextManager
 from safir.datetime import current_datetime
-from structlog import BoundLogger
+from structlog.stdlib import BoundLogger
 
 from .cachemachine import CachemachineClient
 from .config import config


### PR DESCRIPTION
If the profile is production, don't log all the monkey output to the main application log. Keep it only in the per-monkey log. This generates huge amounts of logging volume that we essentially never look at, and those logs aren't in the production log format.

Maintain two separate loggers in the monkey code and log some events to the global logger so that we get a bit of status even though we're not showing the output of every monkey.

Tweak the state machine to hopefully be clearer about shutting down a monkey due to errors, and to avoid calling close on the business more than once.