### PR TITLE
DM-38339: Add notebook to Slack error reports

### DIFF
--- a/src/mobu/business/notebookrunner.py
+++ b/src/mobu/business/notebookrunner.py
@@ -88,9 +88,6 @@ class NotebookRunner(JupyterPythonLoop):
                 msg = f"Invalid notebook {notebook.name}: {str(e)}"
                 raise NotebookRepositoryError(msg)
 
-        # Strip non-code cells.
-        cells = [c for c in cells if c["cell_type"] == "code"]
-
         # Add cell numbers to all the cells, which we'll use to name timing
         # events so that we can find cells that take an excessively long time
         # to run.
@@ -99,6 +96,9 @@ class NotebookRunner(JupyterPythonLoop):
         # some of our notebooks are in the older format without an id.
         for i, cell in enumerate(cells, start=1):
             cell["_index"] = str(i)
+
+        # Strip non-code cells.
+        cells = [c for c in cells if c["cell_type"] == "code"]
 
         return cells
 

--- a/src/mobu/exceptions.py
+++ b/src/mobu/exceptions.py
@@ -95,9 +95,18 @@ class MobuSlackException(SlackException):
         if self.annotations.get("node"):
             node = self.annotations["node"]
             fields.append(SlackTextField(heading="Node", text=node))
-        if self.annotations.get("cell"):
+        if self.annotations.get("notebook"):
+            notebook = self.annotations["notebook"]
+            if self.annotations.get("cell"):
+                cell = self.annotations["cell"]
+                text = f"`{notebook}` cell {cell}"
+                fields.append(SlackTextField(heading="Cell", text=text))
+            else:
+                field = SlackTextField(heading="Notebook", text=notebook)
+                fields.append(field)
+        elif self.annotations.get("cell"):
             cell = self.annotations["cell"]
-            fields.append(SlackTextField(heading="Cell id", text=cell))
+            fields.append(SlackTextField(heading="Cell", text=cell))
         return fields
 
 

--- a/tests/business/notebookrunner_test.py
+++ b/tests/business/notebookrunner_test.py
@@ -200,7 +200,10 @@ async def test_alert(
                         },
                         {
                             "type": "mrkdwn",
-                            "text": "*Cell id*\n`ed399c0a` (#1)",
+                            "text": (
+                                "*Cell*\n`exception.ipynb`"
+                                " cell `ed399c0a` (#2)"
+                            ),
                             "verbatim": True,
                         },
                     ],


### PR DESCRIPTION
The notebook was included in the main part of the Slack message when reporting a code execution failure, but not when reporting other problems such as web socket issues. Add the notebook to the cell in the common fields added from annotations so that it will always be present even for exceptions that don't add it to the main Slack message.