### PR TITLE
DM-38339: Remove lab_settle_time configuration

### DIFF
--- a/src/mobu/models/business/jupyterloginloop.py
+++ b/src/mobu/models/business/jupyterloginloop.py
@@ -40,16 +40,6 @@ class JupyterLoginOptions(BusinessOptions):
         title="Jupyter lab spawning configuration",
     )
 
-    lab_settle_time: int = Field(
-        0,
-        title="How long to wait after spawn before using a lab, in seconds",
-        description=(
-            "Wait this long after a lab successfully spawns before starting"
-            " to use it"
-        ),
-        example=0,
-    )
-
     spawn_settle_time: int = Field(
         10,
         title="How long to wait before polling spawn progress in seconds",

--- a/src/mobu/services/business/jupyterloginloop.py
+++ b/src/mobu/services/business/jupyterloginloop.py
@@ -112,8 +112,6 @@ class JupyterLoginLoop(Business, Generic[T]):
             self.image = None
             if not await self.spawn_lab():
                 return
-            if not await self.lab_settle():
-                return
         await self.lab_login()
         await self.lab_business()
         if self.options.delete_lab:
@@ -172,10 +170,6 @@ class JupyterLoginLoop(Business, Generic[T]):
                 raise JupyterTimeoutError(self.user.username, msg, log)
             else:
                 raise JupyterSpawnError(self.user.username, log)
-
-    async def lab_settle(self) -> bool:
-        with self.timings.start("lab_settle"):
-            return await self.pause(self.options.lab_settle_time)
 
     async def lab_login(self) -> None:
         with self.timings.start("lab_login", self.annotations()):

--- a/tests/business/jupyterloginloop_test.py
+++ b/tests/business/jupyterloginloop_test.py
@@ -35,7 +35,6 @@ async def test_run(
                 "type": "JupyterLoginLoop",
                 "options": {
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "login_idle_time": 0,
                 },
             },
@@ -94,7 +93,6 @@ async def test_reuse_lab(
                 "type": "JupyterLoginLoop",
                 "options": {
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "login_idle_time": 0,
                     "delete_lab": False,
                 },
@@ -128,7 +126,6 @@ async def test_delayed_lab_delete(
                 "type": "JupyterLoginLoop",
                 "options": {
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "login_idle_time": 0,
                     "delete_lab": False,
                 },
@@ -165,7 +162,6 @@ async def test_alert(
                 "type": "JupyterLoginLoop",
                 "options": {
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "login_idle_time": 0,
                     "delete_lab": False,
                 },
@@ -242,7 +238,6 @@ async def test_redirect_loop(
                 "type": "JupyterLoginLoop",
                 "options": {
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "login_idle_time": 0,
                     "delete_lab": False,
                 },
@@ -322,7 +317,6 @@ async def test_spawn_timeout(
                 "type": "JupyterLoginLoop",
                 "options": {
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "spawn_timeout": 1,
                 },
             },
@@ -390,7 +384,6 @@ async def test_spawn_failed(
                 "type": "JupyterLoginLoop",
                 "options": {
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "spawn_timeout": 1,
                 },
             },
@@ -472,7 +465,6 @@ async def test_delete_timeout(
                 "type": "JupyterLoginLoop",
                 "options": {
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "login_idle_time": 0,
                     "delete_timeout": 1,
                 },

--- a/tests/business/jupyterpythonloop_test.py
+++ b/tests/business/jupyterpythonloop_test.py
@@ -33,7 +33,6 @@ async def test_run(
                 "type": "JupyterPythonLoop",
                 "options": {
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "max_executions": 3,
                 },
             },
@@ -87,7 +86,6 @@ async def test_server_shutdown(
                 "type": "JupyterPythonLoop",
                 "options": {
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "max_executions": 3,
                 },
             },
@@ -122,7 +120,6 @@ async def test_alert(
                 "options": {
                     "code": 'raise Exception("some error")',
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "max_executions": 1,
                 },
             },
@@ -232,7 +229,6 @@ async def test_long_error(
                         ),
                     },
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "max_executions": 1,
                 },
             },

--- a/tests/business/notebookrunner_test.py
+++ b/tests/business/notebookrunner_test.py
@@ -48,7 +48,6 @@ async def test_run(
                 "type": "NotebookRunner",
                 "options": {
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "execution_idle_time": 0,
                     "max_executions": 1,
                     "repo_url": str(repo_path),
@@ -125,7 +124,6 @@ async def test_alert(
                 "restart": True,
                 "options": {
                     "spawn_settle_time": 0,
-                    "lab_settle_time": 0,
                     "execution_idle_time": 0,
                     "max_executions": 1,
                     "repo_url": str(repo_path),


### PR DESCRIPTION
This defaulted to 0, we set it to 0 everywhere in the test suite, and we haven't set it to anything other than 0 in Phalanx, so it doesn't appear to be needed. Remove it and simplify the configuration.