### PR TITLE
DM-38339: Handle failures during TAPQueryRunner setup

### DIFF
--- a/src/mobu/exceptions.py
+++ b/src/mobu/exceptions.py
@@ -26,6 +26,7 @@ __all__ = [
     "JupyterTimeoutError",
     "MobuSlackException",
     "MonkeyNotFoundException",
+    "TAPClientError",
 ]
 
 
@@ -279,3 +280,11 @@ class JupyterTimeoutError(MobuSlackException):
 
 class JupyterWebSocketError(MobuSlackException):
     """Unexpected messages on the session WebSocket."""
+
+
+class TAPClientError(MobuSlackException):
+    """Creating a TAP client failed."""
+
+    def __init__(self, user: str, exc: Exception) -> None:
+        msg = f"Unable to create TAP client: {type(exc).__name__}: {str(exc)}"
+        super().__init__(user, msg)


### PR DESCRIPTION
TAPQueryRunner previously was creating a TAP client in __init__, which meant that failure to reach the TAP server caused the entire flock creation to fail. Move creation of the client to startup to correctly follow the Business API, and wrap it in a timer and better exception handling so that we get nice Slack reports.

A business wasn't counting failures during startup as a failed execution, which meant that monkeys that kept failing during startup would show as 100% successful in the summary. Increment the failure count if startup raises an exception to avoid this.