### PR TITLE
DM-38425: Be more robust when getting the running image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Versioning follows [semver](https://semver.org/).
 
 Dependencies are updated to the latest available version during each release. Those changes are not noted here explicitly.
 
+## 5.0.1 (unreleased)
+
+### Bug fixes
+
+- The code to determine the Docker reference and description of the running Nublado image is now more robust against unexpected output.
+
 ## 5.0.0 (2023-03-22)
 
 ### Backwards-incompatible changes

--- a/src/mobu/services/business/nublado.py
+++ b/src/mobu/services/business/nublado.py
@@ -247,10 +247,16 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
             session = await self._client.create_labsession(notebook_name)
         with self.timings.start("execute_setup", self.annotations()):
             image_data = await self._client.run_python(session, _GET_IMAGE)
-            reference, description = image_data.strip().split("\n", 1)
+            if "\n" in image_data:
+                reference, description = image_data.split("\n", 1)
+            else:
+                msg = "Unable to get running image from reply"
+                self.logger.warning(msg, image_data=image_data)
+                reference = None
+                description = None
             self._image = RunningImage(
-                reference=reference or None,
-                description=description or None,
+                reference=reference.strip() if reference else None,
+                description=description.strip() if description else None,
             )
             if self.options.get_node:
                 # Our libraries currently spew warning messages when imported.


### PR DESCRIPTION
Stripping before splitting means that we raise a random ValueError if one of the environment variables was missing. More generally, we got several exceptions that I think may be due to the lab getting shut down while we were asking it questions. Be more robust when parsing the response and treat any unrecognized response as providing no data.