### PR TITLE
DM-38425: Explicitly log out of the hub during startup

### DIFF
--- a/src/mobu/services/business/nublado.py
+++ b/src/mobu/services/business/nublado.py
@@ -136,6 +136,7 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
         return result
 
     async def startup(self) -> None:
+        await self.hub_logout()
         if self.options.jitter:
             with self.timings.start("pre_login_delay"):
                 max_delay = self.options.jitter
@@ -190,6 +191,11 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
         self.logger.info("Logging in to hub")
         with self.timings.start("hub_login"):
             await self._client.hub_login()
+
+    async def hub_logout(self) -> None:
+        self.logger.info("Logging out of hub")
+        with self.timings.start("hub_logout"):
+            await self._client.hub_logout()
 
     async def spawn_lab(self) -> bool:
         with self.timings.start("spawn_lab", self.annotations()) as sw:

--- a/src/mobu/storage/jupyter.py
+++ b/src/mobu/storage/jupyter.py
@@ -265,6 +265,14 @@ class JupyterClient:
                 )
 
     @_convert_exception
+    async def hub_logout(self) -> None:
+        async with self.session.get(self.jupyter_url + "hub/logout") as r:
+            if r.status != 200:
+                raise await JupyterResponseError.from_response(
+                    self.user.username, r
+                )
+
+    @_convert_exception
     async def lab_login(self) -> None:
         self.log.info("Logging into lab")
         lab_url = self.jupyter_url + f"user/{self.user.username}/lab"


### PR DESCRIPTION
We encountered some sort of corrupt user state where all logins failed due to an internal error in the JupyterHub OpenID Connect server saying there was a mismatch of the client ID. Try explicitly logging out during startup and after an error to see if that will correct that problem.