### PR TITLE
DM-38425: Revert error_idle_time change from 5.0.0

### DIFF
--- a/changelog.d/20230504_132825_rra_DM_38425.md
+++ b/changelog.d/20230504_132825_rra_DM_38425.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- The default `error_idle_time` for Nublado-based business is back to 60 seconds instead of 10 minutes. The problem the longer timeout was working around should be fixed in the new Nublado lab controller.

--- a/src/mobu/models/business/nublado.py
+++ b/src/mobu/models/business/nublado.py
@@ -133,17 +133,6 @@ class NubladoBusinessOptions(BusinessOptions):
         60, title="Timeout for deleting a lab in seconds", example=60
     )
 
-    # Zero-to-JupyterHub forces the spawner timeout to 10 minutes, and this is
-    # not unreasonable if the user is trying to spawn an image that isn't
-    # prepulled. Since JupyterHub won't let us delete a lab while it's waiting
-    # for spawn, increase the error idle time to long enough that JupyterHub
-    # will have timed out.
-    error_idle_time: int = Field(
-        600,
-        title="How long to wait after an error before restarting",
-        example=600,
-    )
-
     execution_idle_time: int = Field(
         1,
         title="How long to wait between cell executions in seconds",


### PR DESCRIPTION
In mobu 5.0.0, I had changed the default error_idle_time for those businesses that use Jupyter labs due to problems with recreating the lab after an error. This turned out to be a bug in the new lab controller which should now be fixed, so revert this back to 60 seconds.