### PR TITLE
DM-38425: Use JUPYTER_IMAGE_SPEC, not JUPYTER_IMAGE

### DIFF
--- a/changelog.d/20230504_142201_rra_DM_38425.md
+++ b/changelog.d/20230504_142201_rra_DM_38425.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### Other changes
+
+- Nublado-based notebooks now request the `JUPYTER_IMAGE_SPEC` environment variable instead of `JUPYTER_IMAGE` to get the running image for error reporting purposes. This is now the preferred environment variable and `JUPYTER_IMAGE` is deprecated.

--- a/src/mobu/services/business/nublado.py
+++ b/src/mobu/services/business/nublado.py
@@ -36,7 +36,11 @@ _CHDIR_TEMPLATE = 'import os; os.chdir("{wd}")'
 
 _GET_IMAGE = """
 import os
-print(os.getenv("JUPYTER_IMAGE"), os.getenv("IMAGE_DESCRIPTION"), sep="\\n")
+print(
+    os.getenv("JUPYTER_IMAGE_SPEC"),
+    os.getenv("IMAGE_DESCRIPTION"),
+    sep="\\n",
+)
 """
 """Code to get information about the lab image."""
 


### PR DESCRIPTION
When determining what image is running for error reporting purposes in businesses based on Nublado, ask for JUPYTER_IMAGE_SPEC rather than JUPYTER_IMAGE. The latter is deprecated.