### PR TITLE
DM-38425: Format node and cell as blocks

### DIFF
--- a/changelog.d/20230504_155544_rra.md
+++ b/changelog.d/20230504_155544_rra.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Node and cell information in Slack error reports for Nublado errors are now formatted as full blocks rather than fields, since they are often too wide to fit nicely in the limited width of a Slack Block Kit field.

--- a/tests/business/jupyterpythonloop_test.py
+++ b/tests/business/jupyterpythonloop_test.py
@@ -594,12 +594,15 @@ async def test_code_exception(
                             "text": "*Image*\nRecommended (Weekly 2077_43)",
                             "verbatim": True,
                         },
-                        {
-                            "type": "mrkdwn",
-                            "text": "*Node*\nsome-node",
-                            "verbatim": True,
-                        },
                     ],
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*Node*\nsome-node",
+                        "verbatim": True,
+                    },
                 },
             ],
             "attachments": [
@@ -717,12 +720,15 @@ async def test_long_error(
                             "text": "*Image*\nRecommended (Weekly 2077_43)",
                             "verbatim": True,
                         },
-                        {
-                            "type": "mrkdwn",
-                            "text": "*Node*\nsome-node",
-                            "verbatim": True,
-                        },
                     ],
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*Node*\nsome-node",
+                        "verbatim": True,
+                    },
                 },
             ],
             "attachments": [

--- a/tests/business/notebookrunner_test.py
+++ b/tests/business/notebookrunner_test.py
@@ -192,20 +192,25 @@ async def test_alert(
                             "text": "*Image*\nRecommended (Weekly 2077_43)",
                             "verbatim": True,
                         },
-                        {
-                            "type": "mrkdwn",
-                            "text": "*Node*\nsome-node",
-                            "verbatim": True,
-                        },
-                        {
-                            "type": "mrkdwn",
-                            "text": (
-                                "*Cell*\n`exception.ipynb`"
-                                " cell `ed399c0a` (#2)"
-                            ),
-                            "verbatim": True,
-                        },
                     ],
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "*Node*\nsome-node",
+                        "verbatim": True,
+                    },
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": (
+                            "*Cell*\n`exception.ipynb` cell `ed399c0a` (#2)"
+                        ),
+                        "verbatim": True,
+                    },
                 },
             ],
             "attachments": [


### PR DESCRIPTION
In Google Kubernetes Engine, nodes are often longer than the useful width of a field. Cell is also often longer than the width of a field when there is notebook information and a UUID available. Format both as full Slack Block Kit blocks instead of fields so that they get the full width of the message and don't mess up the column formatting.