### PR TITLE
DM-38425: Adopt current Safir conventions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@ repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
+      - id: trailing-whitespace
       - id: check-yaml
       - id: check-toml
 
@@ -9,15 +10,28 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        additional_dependencies:
-          - toml
+        additional_dependencies: [toml]
 
   - repo: https://github.com/psf/black
     rev: 23.3.0
     hooks:
       - id: black
 
-  - repo: https://github.com/PyCQA/flake8
+  - repo: https://github.com/asottile/blacken-docs
+    rev: 1.13.0
+    hooks:
+      - id: blacken-docs
+        additional_dependencies: [black==23.3.0]
+        args: [-l, '79', -t, py311]
+
+  - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
       - id: flake8
+
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: 6.3.0
+    hooks:
+      - id: pydocstyle
+        additional_dependencies: [toml]
+        files: ^src/

--- a/Makefile
+++ b/Makefile
@@ -25,4 +25,4 @@ update: update-deps init
 
 .PHONY: run
 run:
-	adev runserver --app-factory create_app src/mobu/app.py
+	tox run -e run

--- a/changelog.d/20230510_082737_rra_DM_38425.md
+++ b/changelog.d/20230510_082737_rra_DM_38425.md
@@ -1,0 +1,3 @@
+### New features
+
+- The prefix for mobu routes (`/mobu` by default) can now be configured with `SAFIR_PATH_PREFIX`.

--- a/changelog.d/20230510_083114_rra_DM_38425.md
+++ b/changelog.d/20230510_083114_rra_DM_38425.md
@@ -1,0 +1,3 @@
+### New features
+
+- Uncaught exceptions from mobu's route handlers are now also reported to Slack.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,19 @@ line_length = 79
 known_first_party = ["mobu", "tests"]
 skip = ["docs/conf.py"]
 
+[tool.pydocstyle]
+# Reference: https://www.pydocstyle.org/en/stable/error_codes.html
+convention = "numpy"
+add-ignore = [
+    "D105", # Missing docstring in magic method
+    "D104", # Missing docstring in public package
+    "D102", # Missing docstring in public method (docstring inheritance)
+    "D100", # Missing docstring in public module
+    # Nested classes named Config are used by Pydantic for configuration, and
+    # don't have a meaningful docstring.
+    "D106",
+]
+
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 filterwarnings = [

--- a/src/mobu/config.py
+++ b/src/mobu/config.py
@@ -104,6 +104,12 @@ class Configuration(BaseSettings):
         env="SAFIR_NAME",
     )
 
+    path_prefix: str = Field(
+        "/mobu",
+        title="URL prefix for application API",
+        env="SAFIR_PATH_PREFIX",
+    )
+
     profile: Profile = Field(
         Profile.development,
         title="Application logging profile",

--- a/src/mobu/handlers/external.py
+++ b/src/mobu/handlers/external.py
@@ -8,6 +8,7 @@ from fastapi.responses import FileResponse, JSONResponse
 from safir.datetime import current_datetime
 from safir.metadata import get_metadata
 from safir.models import ErrorModel
+from safir.slack.webhook import SlackRouteErrorHandler
 
 from ..config import config
 from ..dependencies.context import RequestContext, context_dependency
@@ -16,7 +17,7 @@ from ..models.index import Index
 from ..models.monkey import MonkeyData
 from ..models.solitary import SolitaryConfig, SolitaryResult
 
-external_router = APIRouter()
+external_router = APIRouter(route_class=SlackRouteErrorHandler)
 """FastAPI router for all external handlers."""
 
 __all__ = ["external_router"]

--- a/src/mobu/handlers/external.py
+++ b/src/mobu/handlers/external.py
@@ -19,6 +19,8 @@ from ..models.solitary import SolitaryConfig, SolitaryResult
 external_router = APIRouter()
 """FastAPI router for all external handlers."""
 
+__all__ = ["external_router"]
+
 
 class FormattedJSONResponse(JSONResponse):
     """The same as ``fastapi.JSONResponse`` except formatted for humans."""

--- a/src/mobu/handlers/internal.py
+++ b/src/mobu/handlers/internal.py
@@ -9,10 +9,11 @@ or other information that should not be visible outside the Kubernetes cluster.
 
 from fastapi import APIRouter
 from safir.metadata import Metadata, get_metadata
+from safir.slack.webhook import SlackRouteErrorHandler
 
 from ..config import config
 
-internal_router = APIRouter()
+internal_router = APIRouter(route_class=SlackRouteErrorHandler)
 """FastAPI router for all internal handlers."""
 
 __all__ = ["internal_router"]

--- a/src/mobu/handlers/internal.py
+++ b/src/mobu/handlers/internal.py
@@ -12,10 +12,10 @@ from safir.metadata import Metadata, get_metadata
 
 from ..config import config
 
-__all__ = ["get_index", "internal_router"]
-
 internal_router = APIRouter()
 """FastAPI router for all internal handlers."""
+
+__all__ = ["internal_router"]
 
 
 @internal_router.get(

--- a/src/mobu/main.py
+++ b/src/mobu/main.py
@@ -11,22 +11,20 @@ import asyncio
 from importlib.metadata import metadata, version
 
 import structlog
-from fastapi import FastAPI, Request, status
-from fastapi.responses import JSONResponse
+from fastapi import FastAPI
+from safir.fastapi import ClientRequestError, client_request_error_handler
 from safir.logging import Profile, configure_logging, configure_uvicorn_logging
 from safir.middleware.x_forwarded import XForwardedMiddleware
-from safir.models import ErrorLocation
 from safir.slack.webhook import SlackRouteErrorHandler
 
 from .asyncio import schedule_periodic
 from .config import config
 from .dependencies.context import context_dependency
-from .exceptions import FlockNotFoundException, MonkeyNotFoundException
 from .handlers.external import external_router
 from .handlers.internal import internal_router
 from .status import post_status
 
-__all__ = ["app", "config"]
+__all__ = ["app"]
 
 
 configure_logging(
@@ -58,6 +56,9 @@ if config.alert_hook:
     SlackRouteErrorHandler.initialize(config.alert_hook, "mobu", logger)
     logger.debug("Initialized Slack webhook")
 
+# Enable the generic exception handler for client errors.
+app.exception_handler(ClientRequestError)(client_request_error_handler)
+
 
 @app.on_event("startup")
 async def startup_event() -> None:
@@ -78,39 +79,3 @@ async def shutdown_event() -> None:
         await app.state.periodic_status
     except asyncio.CancelledError:
         pass
-
-
-@app.exception_handler(FlockNotFoundException)
-async def flock_not_found_exception_handler(
-    request: Request, exc: FlockNotFoundException
-) -> JSONResponse:
-    return JSONResponse(
-        status_code=status.HTTP_404_NOT_FOUND,
-        content={
-            "detail": [
-                {
-                    "loc": [ErrorLocation.path, "flock"],
-                    "msg": f"Flock for {exc.flock} not found",
-                    "type": "flock_not_found",
-                }
-            ]
-        },
-    )
-
-
-@app.exception_handler(MonkeyNotFoundException)
-async def monkey_not_found_exception_handler(
-    request: Request, exc: MonkeyNotFoundException
-) -> JSONResponse:
-    return JSONResponse(
-        status_code=status.HTTP_404_NOT_FOUND,
-        content={
-            "detail": [
-                {
-                    "loc": [ErrorLocation.path, "monkey"],
-                    "msg": f"Monkey for {exc.monkey} not found",
-                    "type": "monkey_not_found",
-                }
-            ]
-        },
-    )

--- a/src/mobu/main.py
+++ b/src/mobu/main.py
@@ -28,7 +28,7 @@ __all__ = ["app", "config"]
 
 
 configure_logging(
-    profile=config.profile, log_level=config.log_level, name="mobu"
+    name="mobu", profile=config.profile, log_level=config.log_level
 )
 if config.profile == Profile.production:
     configure_uvicorn_logging(config.log_level)
@@ -37,15 +37,15 @@ app = FastAPI(
     title="mobu",
     description=metadata("mobu")["Summary"],
     version=version("mobu"),
-    openapi_url=f"/{config.name}/openapi.json",
-    docs_url=f"/{config.name}/docs",
-    redoc_url=f"/{config.name}/redoc",
+    openapi_url=f"{config.path_prefix}/openapi.json",
+    docs_url=f"{config.path_prefix}/docs",
+    redoc_url=f"{config.path_prefix}/redoc",
 )
 """The main FastAPI application for mobu."""
 
 # Attach the routers.
 app.include_router(internal_router)
-app.include_router(external_router, prefix=f"/{config.name}")
+app.include_router(external_router, prefix=config.path_prefix)
 
 # Add middleware.
 app.add_middleware(XForwardedMiddleware)

--- a/src/mobu/services/business/nublado.py
+++ b/src/mobu/services/business/nublado.py
@@ -113,7 +113,7 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
 
     @abstractmethod
     async def execute_code(self, session: JupyterLabSession) -> None:
-        """The core of the execution loop.
+        """Execute some code inside the Jupyter lab.
 
         Must be overridden by subclasses to use the provided lab session to
         perform whatever operations are desired inside the lab. If multiple
@@ -158,7 +158,6 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
                 self.logger.warning(msg)
 
     async def execute(self) -> None:
-        """The work done in each iteration of the loop."""
         if self.options.delete_lab or await self._client.is_lab_stopped():
             self._image = None
             if not await self.spawn_lab():
@@ -171,7 +170,7 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
             await self.delete_lab()
 
     async def execution_idle(self) -> bool:
-        """Executed between each unit of work execution.
+        """Pause between each unit of work execution.
 
         This is not used directly by `NubladoBusiness`. It should be called by
         subclasses in `execute_code` in between each block of code that is
@@ -184,7 +183,6 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
         await self.delete_lab()
 
     async def idle(self) -> None:
-        """The idle pause at the end of each loop."""
         if self.options.jitter:
             self.logger.info("Idling...")
             with self.timings.start("idle"):

--- a/src/mobu/services/flock.py
+++ b/src/mobu/services/flock.py
@@ -12,7 +12,7 @@ from httpx import AsyncClient
 from safir.datetime import current_datetime
 from structlog.stdlib import BoundLogger
 
-from ..exceptions import MonkeyNotFoundException
+from ..exceptions import MonkeyNotFoundError
 from ..models.flock import FlockConfig, FlockData, FlockSummary
 from ..models.user import AuthenticatedUser, User, UserSpec
 from .monkey import Monkey
@@ -60,10 +60,26 @@ class Flock:
         )
 
     def get_monkey(self, name: str) -> Monkey:
-        """Retrieve a given monkey by name."""
+        """Retrieve a given monkey by name.
+
+        Parameters
+        ----------
+        name
+            Name of monkey to return.
+
+        Returns
+        -------
+        Monkey
+            Requested monkey.
+
+        Raises
+        ------
+        MonkeyNotFoundError
+            Raised if no monkey was found with that name.
+        """
         monkey = self._monkeys.get(name)
         if not monkey:
-            raise MonkeyNotFoundException(name)
+            raise MonkeyNotFoundError(name)
         return monkey
 
     def list_monkeys(self) -> list[str]:

--- a/src/mobu/services/manager.py
+++ b/src/mobu/services/manager.py
@@ -10,7 +10,7 @@ from httpx import AsyncClient
 from structlog.stdlib import BoundLogger
 
 from ..config import config
-from ..exceptions import FlockNotFoundException
+from ..exceptions import FlockNotFoundError
 from ..models.flock import FlockConfig, FlockSummary
 from .flock import Flock
 
@@ -98,12 +98,12 @@ class FlockManager:
 
         Raises
         ------
-        FlockNotFoundException
+        FlockNotFoundError
             Raised if no flock was found with that name.
         """
         flock = self._flocks.get(name)
         if flock is None:
-            raise FlockNotFoundException(name)
+            raise FlockNotFoundError(name)
         return flock
 
     def list_flocks(self) -> list[str]:
@@ -133,9 +133,14 @@ class FlockManager:
         ----------
         name
             Name of flock to stop.
+
+        Raises
+        ------
+        FlockNotFoundError
+            Raised if no flock was found with that name.
         """
         flock = self._flocks.get(name)
         if flock is None:
-            raise FlockNotFoundException(name)
+            raise FlockNotFoundError(name)
         del self._flocks[name]
         await flock.stop()

--- a/src/monkeyflocker/cli.py
+++ b/src/monkeyflocker/cli.py
@@ -13,10 +13,7 @@ from .client import MonkeyflockerClient
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(message="%(version)s")
 def main() -> None:
-    """monkeyflocker main.
-
-    Command-line interface to manage mobu monkeys.
-    """
+    """Command-line interface to manage mobu monkeys."""
     pass
 
 


### PR DESCRIPTION
- Enable blacken-docs and pydocstyle
- Allow configuration of the path prefix using the standard Safir environment variable
- Enable Slack reporting of uncaught exceptions from the route handlers
- Use the Safir ClientRequestError framework
- Fix the Makefile run target