### PR TITLE
DM-38425: Split out Gafaelfawr storage layer and use models

### DIFF
--- a/src/mobu/constants.py
+++ b/src/mobu/constants.py
@@ -1,7 +1,34 @@
 """Global constants for mobu."""
 
+from __future__ import annotations
+
+from datetime import timedelta
+
+__all__ = [
+    "NOTEBOOK_REPO_URL",
+    "NOTEBOOK_REPO_BRANCH",
+    "TOKEN_LIFETIME",
+    "USERNAME_REGEX",
+]
+
 NOTEBOOK_REPO_URL = "https://github.com/lsst-sqre/notebook-demo.git"
 """Default notebook repository for NotebookRunner."""
 
 NOTEBOOK_REPO_BRANCH = "prod"
 """Default repository branch for NotebookRunner."""
+
+TOKEN_LIFETIME = timedelta(days=365)
+"""Token lifetime for mobu's service tokens.
+
+mobu currently has no mechanism for refreshing tokens while running, so this
+should be long enough that mobu will be restarted before the tokens expire.
+An expiration exists primarily to ensure that the tokens don't accumulate
+forever.
+"""
+
+# This must be kept in sync with Gafaelfawr until we can import the models
+# from Gafaelfawr directly.
+USERNAME_REGEX = (
+    "^[a-z0-9](?:[a-z0-9]|-[a-z0-9])*[a-z](?:[a-z0-9]|-[a-z0-9])*$"
+)
+"""Regex matching all valid usernames."""

--- a/src/mobu/services/manager.py
+++ b/src/mobu/services/manager.py
@@ -12,6 +12,7 @@ from structlog.stdlib import BoundLogger
 from ..config import config
 from ..exceptions import FlockNotFoundError
 from ..models.flock import FlockConfig, FlockSummary
+from ..storage.gafaelfawr import GafaelfawrStorage
 from .flock import Flock
 
 __all__ = ["FlockManager"]
@@ -26,13 +27,21 @@ class FlockManager:
 
     Parameters
     ----------
+    gafaelfawr_storage
+        Gafaelfawr storage client.
     http_client
         Shared HTTP client.
     logger
         Global logger to use for process-wide (not monkey) logging.
     """
 
-    def __init__(self, http_client: AsyncClient, logger: BoundLogger) -> None:
+    def __init__(
+        self,
+        gafaelfawr_storage: GafaelfawrStorage,
+        http_client: AsyncClient,
+        logger: BoundLogger,
+    ) -> None:
+        self._gafaelfawr = gafaelfawr_storage
         self._http_client = http_client
         self._logger = logger
         self._flocks: dict[str, Flock] = {}
@@ -74,6 +83,7 @@ class FlockManager:
         flock = Flock(
             flock_config=flock_config,
             scheduler=self._scheduler,
+            gafaelfawr_storage=self._gafaelfawr,
             http_client=self._http_client,
             logger=self._logger,
         )

--- a/src/mobu/storage/gafaelfawr.py
+++ b/src/mobu/storage/gafaelfawr.py
@@ -1,0 +1,150 @@
+"""Manage Gafaelfawr users and tokens."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from httpx import AsyncClient, HTTPError
+from pydantic import BaseModel, Field, ValidationError
+from safir.datetime import current_datetime
+from structlog.stdlib import BoundLogger
+
+from ..config import config
+from ..constants import TOKEN_LIFETIME, USERNAME_REGEX
+from ..exceptions import GafaelfawrParseError, GafaelfawrWebError
+from ..models.user import AuthenticatedUser, User
+
+__all__ = ["GafaelfawrStorage"]
+
+
+class _TokenType(Enum):
+    """The class of token.
+
+    This is copied from Gafaelfawr and should be replaced with using the
+    Gafaelfawr models directly once they're available.
+    """
+
+    session = "session"
+    user = "user"
+    notebook = "notebook"
+    internal = "internal"
+    service = "service"
+
+
+class _AdminTokenRequest(BaseModel):
+    """Request by a Gafaelfawr token administrator to create a token.
+
+    This is copied from Gafaelfawr and should be replaced with using the
+    Gafaelfawr models directly once they're available.
+    """
+
+    username: str = Field(
+        ..., min_length=1, max_length=64, regex=USERNAME_REGEX
+    )
+    token_type: _TokenType = Field(...)
+    scopes: list[str] = Field([])
+    expires: Optional[datetime] = Field(None)
+    name: Optional[str] = Field(None, min_length=1)
+    uid: Optional[int] = Field(None, ge=1)
+    gid: Optional[int] = Field(None, ge=1)
+
+
+class _NewToken(BaseModel):
+    """Response to a token creation request.
+
+    This is copied from Gafaelfawr and should be replaced with using the
+    Gafaelfawr models directly once they're available.
+    """
+
+    token: str = Field(...)
+
+
+class GafaelfawrStorage:
+    """Manage users and authentication tokens.
+
+    mobu uses bot users to run its tests. Those users may be pre-existing or
+    manufactured on the fly by mobu. Either way, mobu creates new service
+    tokens for the configured users, and then provides those usernames and
+    tokens to monkeys to use for executing their business.
+
+    This class handles the call to Gafaelfawr to create the service token.
+
+    Parameters
+    ----------
+    http_client
+        Shared HTTP client.
+    logger
+        Logger to use.
+    """
+
+    def __init__(self, http_client: AsyncClient, logger: BoundLogger) -> None:
+        self._client = http_client
+        self._logger = logger
+
+        if not config.environment_url:
+            raise RuntimeError("environment_url not set")
+        base_url = str(config.environment_url).rstrip("/")
+        self._token_url = base_url + "/auth/api/v1/tokens"
+
+    async def create_service_token(
+        self, user: User, scopes: list[str]
+    ) -> AuthenticatedUser:
+        """Create a service token for a user.
+
+        Parameters
+        ----------
+        user
+            Metadata for the user. If ``uid`` or ``gid`` are set for the user,
+            they will be stored with the token and override Gafaelfawr's
+            normal user metadata source.
+        scopes
+            Scopes the requested token should have.
+
+        Returns
+        -------
+        AuthenticatedUser
+            Authenticated user with their metadata, scopes, and token.
+
+        Raises
+        ------
+        GafaelfawrParseError
+            Raised if the input or output data for Gafaelfawr's token call
+            could not be parsed.
+        GafaelfawrWebError
+            Raised if an HTTP protocol error occurred talking to Gafaelfawr.
+        """
+        request = _AdminTokenRequest(
+            username=user.username,
+            token_type=_TokenType.service,
+            scopes=scopes,
+            expires=current_datetime() + TOKEN_LIFETIME,
+            name="Mobu Test User",
+            uid=user.uidnumber,
+            gid=user.gidnumber or user.uidnumber,
+        )
+        try:
+            # The awkward JSON generation ensures that datetime fields are
+            # properly serialized using the model rather than left as datetime
+            # objects, which httpx will not understand. Pydantic v2 will offer
+            # a better way to do this.
+            r = await self._client.post(
+                self._token_url,
+                headers={"Authorization": f"Bearer {config.gafaelfawr_token}"},
+                json=json.loads(request.json(exclude_none=True)),
+            )
+            r.raise_for_status()
+            token = _NewToken.parse_obj(r.json())
+            return AuthenticatedUser(
+                username=user.username,
+                uidnumber=request.uid,
+                gidnumber=request.gid,
+                token=token.token,
+                scopes=scopes,
+            )
+        except HTTPError as e:
+            raise GafaelfawrWebError.from_exception(e, user.username)
+        except ValidationError as e:
+            raise GafaelfawrParseError.from_exception(e, user.username)

--- a/tests/storage/gafaelfawr_test.py
+++ b/tests/storage/gafaelfawr_test.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import pytest
 import respx
+import structlog
 from safir.dependencies.http_client import http_client_dependency
 
-from mobu.models.user import AuthenticatedUser, User
+from mobu.models.user import User
+from mobu.storage.gafaelfawr import GafaelfawrStorage
 
-from .support.gafaelfawr import mock_gafaelfawr
+from ..support.gafaelfawr import mock_gafaelfawr
 
 
 @pytest.mark.asyncio
@@ -18,8 +20,12 @@ async def test_generate_token(respx_mock: respx.Router) -> None:
     scopes = ["exec:notebook"]
 
     client = await http_client_dependency()
-    user = await AuthenticatedUser.create(config, scopes, client)
+    logger = structlog.get_logger(__file__)
+    gafaelfawr = GafaelfawrStorage(client, logger)
+
+    user = await gafaelfawr.create_service_token(config, scopes)
     assert user.username == "someuser"
     assert user.uidnumber == 1234
+    assert user.gidnumber == 1234
     assert user.scopes == ["exec:notebook"]
     assert user.token.startswith("gt-")

--- a/tests/support/gafaelfawr.py
+++ b/tests/support/gafaelfawr.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 import base64
 import json
 import os
-import time
+from datetime import datetime
 from typing import Optional
 from unittest.mock import ANY
 
 import respx
 from httpx import Request, Response
+from safir.datetime import current_datetime
 
 from mobu.config import config
 
@@ -54,8 +55,7 @@ def mock_gafaelfawr(
         assert request.headers["Authorization"] == f"Bearer {admin_token}"
         expected = {
             "username": username if username else ANY,
-            "token_type": "user",
-            "token_name": ANY,
+            "token_type": "service",
             "scopes": ["exec:notebook"],
             "expires": ANY,
             "name": "Mobu Test User",
@@ -69,8 +69,7 @@ def mock_gafaelfawr(
             expected["gid"] = ANY
         body = json.loads(request.content)
         assert body == expected
-        assert body["token_name"].startswith("mobu ")
-        assert body["expires"] > time.time()
+        assert datetime.fromisoformat(body["expires"]) > current_datetime()
         response = {"token": make_gafaelfawr_token(body["username"])}
         return Response(200, json=response)
 


### PR DESCRIPTION
Rather than embedding the Gafaelfawr client in the AuthenticatedUser model, separate out a Gafaelfawr storage client. Use copies of the Gafaelfawr models rather than sending and receiving raw JSON. These can be replaced with the real Gafaelfawr models once those are available from PyPI.

Take advantage of this to use Pydantic for the parsing and capture Gafaelfawr parsing errors in a Slack-reportable exception.