### PR TITLE
DM-38425: Change how we force a refresh of JupyterHub auth

### DIFF
--- a/src/mobu/storage/jupyter.py
+++ b/src/mobu/storage/jupyter.py
@@ -469,21 +469,15 @@ class JupyterClient:
 
     @_convert_exception
     async def auth_to_hub(self) -> None:
-        """Retrieve the JupyterHub login page.
+        """Retrieve the JupyterHub home page.
 
         This forces a refresh of the authentication cookies set in the client
         session, which may be required to use API calls that return 401 errors
         instead of redirecting the user to log in.
         """
-        url = self._url_for("hub/login")
-        r = await self._client.get(url, follow_redirects=False)
-
-        # JupyterHub returns a 302 redirect to either the spawn form or the
-        # running lab on success, but we don't want to follow that
-        # redirect. We only want to accept and set the cookies included in the
-        # initial response.
-        if r.status_code >= 400:
-            r.raise_for_status()
+        url = self._url_for("hub/home")
+        r = await self._client.get(url)
+        r.raise_for_status()
 
     @_convert_exception
     async def auth_to_lab(self) -> None:

--- a/tests/support/jupyter.py
+++ b/tests/support/jupyter.py
@@ -373,7 +373,7 @@ class MockJupyterWebSocket(Mock):
 def mock_jupyter(respx_mock: respx.Router) -> MockJupyter:
     """Set up a mock JupyterHub and lab."""
     mock = MockJupyter()
-    respx_mock.get(_url("hub/login")).mock(side_effect=mock.login)
+    respx_mock.get(_url("hub/home")).mock(side_effect=mock.login)
     respx_mock.get(_url("hub/spawn")).mock(return_value=Response(200))
     respx_mock.post(_url("hub/spawn")).mock(side_effect=mock.spawn)
     regex = _url_regex("hub/spawn-pending/[^/]+$")


### PR DESCRIPTION
Previously, the Jupyter client was requesting the login page with redirects disabled, which does not appear to be enough to force an authentication refresh and allow us to make API calls. Try fetching the hub home page instead with redirects enabled.