### PR TITLE
DM-38425: Allow enabling of lab debugging

### DIFF
--- a/changelog.d/20230511_132330_rra_DM_38425.md
+++ b/changelog.d/20230511_132330_rra_DM_38425.md
@@ -1,0 +1,3 @@
+### New features
+
+- Nublado-based businesses can now set `debug` to true in the image specification to request that debugging be enabled in the spawned Jupyter lab.

--- a/src/mobu/models/business/nublado.py
+++ b/src/mobu/models/business/nublado.py
@@ -58,6 +58,8 @@ class NubladoImage(BaseModel, metaclass=ABCMeta):
         description="Must be one of the sizes understood by Nublado.",
     )
 
+    debug: bool = Field(False, title="Whether to enable lab debugging")
+
     @abstractmethod
     def to_spawn_form(self) -> dict[str, str]:
         """Convert to data suitable for posting to JupyterHub's spawn form.
@@ -83,10 +85,13 @@ class NubladoImageByClass(NubladoImage):
     )
 
     def to_spawn_form(self) -> dict[str, str]:
-        return {
+        result = {
             "image_class": self.image_class.value,
             "size": self.size.value,
         }
+        if self.debug:
+            result["enable_debug"] = "true"
+        return result
 
 
 class NubladoImageByReference(NubladoImage):
@@ -99,7 +104,13 @@ class NubladoImageByReference(NubladoImage):
     reference: str = Field(..., title="Docker reference of lab image to spawn")
 
     def to_spawn_form(self) -> dict[str, str]:
-        return {"image_list": self.reference, "size": self.size.value}
+        result = {
+            "image_list": self.reference,
+            "size": self.size.value,
+        }
+        if self.debug:
+            result["enable_debug"] = "true"
+        return result
 
 
 class NubladoImageByTag(NubladoImage):
@@ -112,7 +123,10 @@ class NubladoImageByTag(NubladoImage):
     tag: str = Field(..., title="Tag of image to spawn")
 
     def to_spawn_form(self) -> dict[str, str]:
-        return {"image_tag": self.tag, "size": self.size.value}
+        result = {"image_tag": self.tag, "size": self.size.value}
+        if self.debug:
+            result["enable_debug"] = "true"
+        return result
 
 
 class NubladoBusinessOptions(BusinessOptions):

--- a/src/mobu/storage/jupyter.py
+++ b/src/mobu/storage/jupyter.py
@@ -731,11 +731,14 @@ class JupyterClient:
         self, image: JupyterCachemachineImage
     ) -> dict[str, str]:
         """Construct the form to submit to the JupyterHub login page."""
-        return {
+        result = {
             "image_list": str(image),
             "image_dropdown": "use_image_from_dropdown",
             "size": self._config.size.value,
         }
+        if self._config.debug:
+            result["enable_debug"] = "true"
+        return result
 
     def _url_for(self, partial: str) -> str:
         """Construct a JupyterHub or Jupyter lab URL from a partial URL.

--- a/tests/business/jupyterpythonloop_test.py
+++ b/tests/business/jupyterpythonloop_test.py
@@ -854,6 +854,7 @@ async def test_lab_controller(
                         "image": {
                             "image_class": "latest-daily",
                             "size": "Medium",
+                            "debug": True,
                         },
                     },
                 },
@@ -861,6 +862,7 @@ async def test_lab_controller(
         )
         assert r.status_code == 201
         assert jupyter.lab_form["testuser"] == {
+            "enable_debug": "true",
             "image_class": "latest-daily",
             "size": "Medium",
         }


### PR DESCRIPTION
Add a debug flag to the configuration for any Nublado-based business that allows turning on lab debugging by passing the enable_debug flag through the JupyterHub spawner form.