### PR TITLE
DM-38425: Remove WebSocket message size limit

### DIFF
--- a/src/mobu/constants.py
+++ b/src/mobu/constants.py
@@ -26,6 +26,13 @@ An expiration exists primarily to ensure that the tokens don't accumulate
 forever.
 """
 
+WEBSOCKET_MESSAGE_SIZE_LIMIT: int | None = None
+"""Largest WebSocket message size allowed from lab (in bytes).
+
+This has to be large enough to hold HTML and image output from executing
+notebook cells, even though we discard that data. Set to `None` for no limit.
+"""
+
 # This must be kept in sync with Gafaelfawr until we can import the models
 # from Gafaelfawr directly.
 USERNAME_REGEX = (

--- a/src/mobu/storage/jupyter.py
+++ b/src/mobu/storage/jupyter.py
@@ -27,6 +27,7 @@ from websockets.client import connect as websocket_connect
 from websockets.exceptions import WebSocketException
 
 from ..config import config
+from ..constants import WEBSOCKET_MESSAGE_SIZE_LIMIT
 from ..exceptions import (
     CodeExecutionError,
     JupyterWebError,
@@ -228,7 +229,9 @@ class JupyterLabSession:
         self._logger.debug("Opening WebSocket connection")
         try:
             self._socket = await websocket_connect(
-                self._url_for_websocket(url), extra_headers=headers
+                self._url_for_websocket(url),
+                extra_headers=headers,
+                max_size=WEBSOCKET_MESSAGE_SIZE_LIMIT,
             ).__aenter__()
         except WebSocketException as e:
             user = self._username

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,7 @@ def jupyter(respx_mock: respx.Router) -> Iterator[MockJupyter]:
     # ourselves.
     @asynccontextmanager
     async def mock_connect(
-        url: str, extra_headers: dict[str, str]
+        url: str, extra_headers: dict[str, str], max_size: int | None
     ) -> AsyncIterator[MockJupyterWebSocket]:
         yield mock_jupyter_websocket(url, extra_headers, jupyter_mock)
 


### PR DESCRIPTION
Add a constant so that we can configure a WebSocket message size limit in the future, but remove the default limit to match the previous aiohttp behavior. We have some notebooks that return images as part of cell execution and they exceeded the default 1MB limit on WebSocket message sizes.