### PR TITLE
DM-38425: Increase the WebSocket open timeout

### DIFF
--- a/src/mobu/constants.py
+++ b/src/mobu/constants.py
@@ -33,6 +33,9 @@ This has to be large enough to hold HTML and image output from executing
 notebook cells, even though we discard that data. Set to `None` for no limit.
 """
 
+WEBSOCKET_OPEN_TIMEOUT: int = 60
+"""How long to wait for a WebSocket connection to open (in seconds)."""
+
 # This must be kept in sync with Gafaelfawr until we can import the models
 # from Gafaelfawr directly.
 USERNAME_REGEX = (

--- a/src/mobu/storage/jupyter.py
+++ b/src/mobu/storage/jupyter.py
@@ -27,7 +27,7 @@ from websockets.client import connect as websocket_connect
 from websockets.exceptions import WebSocketException
 
 from ..config import config
-from ..constants import WEBSOCKET_MESSAGE_SIZE_LIMIT
+from ..constants import WEBSOCKET_MESSAGE_SIZE_LIMIT, WEBSOCKET_OPEN_TIMEOUT
 from ..exceptions import (
     CodeExecutionError,
     JupyterWebError,
@@ -231,6 +231,7 @@ class JupyterLabSession:
             self._socket = await websocket_connect(
                 self._url_for_websocket(url),
                 extra_headers=headers,
+                open_timeout=WEBSOCKET_OPEN_TIMEOUT,
                 max_size=WEBSOCKET_MESSAGE_SIZE_LIMIT,
             ).__aenter__()
         except WebSocketException as e:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,10 @@ def jupyter(respx_mock: respx.Router) -> Iterator[MockJupyter]:
     # ourselves.
     @asynccontextmanager
     async def mock_connect(
-        url: str, extra_headers: dict[str, str], max_size: int | None
+        url: str,
+        extra_headers: dict[str, str],
+        max_size: int | None,
+        open_timeout: int,
     ) -> AsyncIterator[MockJupyterWebSocket]:
         yield mock_jupyter_websocket(url, extra_headers, jupyter_mock)
 


### PR DESCRIPTION
10 seconds, the default, may be too fast for the kernel to start. Try 60 seconds. It looks like aiohttp was using 300 seconds, so we can go as high as that.