### PR TITLE
DM-38425: Include the monkey and flock in Slack exceptions

### DIFF
--- a/changelog.d/20230515_104223_rra_DM_38425.md
+++ b/changelog.d/20230515_104223_rra_DM_38425.md
@@ -1,0 +1,4 @@
+### New features
+
+- Slack alerts from monkeys now include the flock and monkey name as a field in the alert.
+- Unexpected business exceptions now include an "Exception type" heading and use "Failed at" instead of "Date" to match the display of expected exceptions.

--- a/changelog.d/20230515_112657_rra_DM_38425.md
+++ b/changelog.d/20230515_112657_rra_DM_38425.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- mobu now uses the [Ruff](https://beta.ruff.rs/docs/) linter instead of flake8, isort, and pydocstyle.

--- a/src/mobu/exceptions.py
+++ b/src/mobu/exceptions.py
@@ -163,6 +163,17 @@ class MobuSlackException(SlackException):
         When the operation started.
     failed_at
         When the operation failed (defaults to the current time).
+
+    Attributes
+    ----------
+    started_at
+        When the operation that ended in an exception started.
+    monkey
+        The running monkey in which the exception happened.
+    event
+        Name of the business event that provoked the exception.
+    annotations
+        Additional annotations for the running business.
     """
 
     def __init__(
@@ -175,6 +186,7 @@ class MobuSlackException(SlackException):
     ) -> None:
         super().__init__(msg, user, failed_at=failed_at)
         self.started_at = started_at
+        self.monkey: str | None = None
         self.event: str | None = None
         self.annotations: dict[str, str] = {}
 
@@ -238,6 +250,8 @@ class MobuSlackException(SlackException):
             started_at = format_datetime_for_logging(self.started_at)
             field = SlackTextField(heading="Started at", text=started_at)
             fields.insert(0, field)
+        if self.monkey:
+            fields.append(SlackTextField(heading="Monkey", text=self.monkey))
         if self.user:
             fields.append(SlackTextField(heading="User", text=self.user))
         if self.event:

--- a/src/mobu/services/flock.py
+++ b/src/mobu/services/flock.py
@@ -135,6 +135,7 @@ class Flock:
         """Create a monkey that will run as a given user."""
         return Monkey(
             name=user.username,
+            flock=self.name,
             business_config=self._config.business,
             user=user,
             http_client=self._http_client,

--- a/tests/business/jupyterpythonloop_test.py
+++ b/tests/business/jupyterpythonloop_test.py
@@ -222,6 +222,11 @@ async def test_hub_failed(
                         },
                         {
                             "type": "mrkdwn",
+                            "text": "*Monkey*\ntest/testuser2",
+                            "verbatim": True,
+                        },
+                        {
+                            "type": "mrkdwn",
                             "text": "*User*\ntestuser2",
                             "verbatim": True,
                         },
@@ -308,6 +313,11 @@ async def test_redirect_loop(
                         },
                         {
                             "type": "mrkdwn",
+                            "text": "*Monkey*\ntest/testuser1",
+                            "verbatim": True,
+                        },
+                        {
+                            "type": "mrkdwn",
                             "text": "*User*\ntestuser1",
                             "verbatim": True,
                         },
@@ -385,6 +395,11 @@ async def test_spawn_timeout(
                         },
                         {
                             "type": "mrkdwn",
+                            "text": "*Monkey*\ntest/testuser1",
+                            "verbatim": True,
+                        },
+                        {
+                            "type": "mrkdwn",
                             "text": "*User*\ntestuser1",
                             "verbatim": True,
                         },
@@ -450,6 +465,11 @@ async def test_spawn_failed(
                         {
                             "type": "mrkdwn",
                             "text": "*Exception type*\nJupyterSpawnError",
+                            "verbatim": True,
+                        },
+                        {
+                            "type": "mrkdwn",
+                            "text": "*Monkey*\ntest/testuser1",
                             "verbatim": True,
                         },
                         {
@@ -542,6 +562,11 @@ async def test_delete_timeout(
                         },
                         {
                             "type": "mrkdwn",
+                            "text": "*Monkey*\ntest/testuser1",
+                            "verbatim": True,
+                        },
+                        {
+                            "type": "mrkdwn",
                             "text": "*User*\ntestuser1",
                             "verbatim": True,
                         },
@@ -612,6 +637,11 @@ async def test_code_exception(
                         {
                             "type": "mrkdwn",
                             "text": "*Exception type*\nCodeExecutionError",
+                            "verbatim": True,
+                        },
+                        {
+                            "type": "mrkdwn",
+                            "text": "*Monkey*\ntest/testuser1",
                             "verbatim": True,
                         },
                         {
@@ -743,6 +773,11 @@ async def test_long_error(
                         {
                             "type": "mrkdwn",
                             "text": "*Exception type*\nCodeExecutionError",
+                            "verbatim": True,
+                        },
+                        {
+                            "type": "mrkdwn",
+                            "text": "*Monkey*\ntest/testuser1",
                             "verbatim": True,
                         },
                         {

--- a/tests/business/notebookrunner_test.py
+++ b/tests/business/notebookrunner_test.py
@@ -183,6 +183,11 @@ async def test_alert(
                         },
                         {
                             "type": "mrkdwn",
+                            "text": "*Monkey*\ntest/testuser1",
+                            "verbatim": True,
+                        },
+                        {
+                            "type": "mrkdwn",
                             "text": "*User*\ntestuser1",
                             "verbatim": True,
                         },

--- a/tests/business/tapqueryrunner_test.py
+++ b/tests/business/tapqueryrunner_test.py
@@ -121,6 +121,11 @@ async def test_setup_error(
                         },
                         {
                             "type": "mrkdwn",
+                            "text": "*Monkey*\ntest/tapuser",
+                            "verbatim": True,
+                        },
+                        {
+                            "type": "mrkdwn",
                             "text": "*User*\ntapuser",
                             "verbatim": True,
                         },
@@ -181,6 +186,11 @@ async def test_alert(
                         {
                             "type": "mrkdwn",
                             "text": "*Exception type*\nCodeExecutionError",
+                            "verbatim": True,
+                        },
+                        {
+                            "type": "mrkdwn",
+                            "text": "*Monkey*\ntest/testuser1",
                             "verbatim": True,
                         },
                         {


### PR DESCRIPTION
When reporting business exceptions to Slack, include the monkey and, if relevant, the flock. Change the fields for reporting unexpected exceptions (ones that don't know how to format themselves for Slack) to use the same field names as supported exceptions.