### PR TITLE
DM-39325: Revert cell numbering to only count code cells

### DIFF
--- a/changelog.d/20230522_085712_rra_DM_39325.md
+++ b/changelog.d/20230522_085712_rra_DM_39325.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Revert change in 5.0.0 to number all cells, and go back to counting only code cells for numbering purposes. This matches the way cell numbers are displayed in the Jupyter lab UI.

--- a/src/mobu/services/business/notebookrunner.py
+++ b/src/mobu/services/business/notebookrunner.py
@@ -109,14 +109,16 @@ class NotebookRunner(NubladoBusiness):
                 msg = f"Invalid notebook {notebook.name}: {e!s}"
                 raise NotebookRepositoryError(msg, self.user.username) from e
 
-        # Add cell numbers to all the cells, which we'll use in exception
-        # reporting and to annotate timing events so that we can find cells
-        # that take an excessively long time to run.
-        for i, cell in enumerate(cells, start=1):
-            cell["_index"] = str(i)
-
         # Strip non-code cells.
         cells = [c for c in cells if c["cell_type"] == "code"]
+
+        # Add cell numbers to all the cells, which we'll use in exception
+        # reporting and to annotate timing events so that we can find cells
+        # that take an excessively long time to run. This should be done after
+        # stripping non-code cells, since the UI for notebooks displays cell
+        # numbers only counting code cells.
+        for i, cell in enumerate(cells, start=1):
+            cell["_index"] = str(i)
 
         return cells
 

--- a/tests/business/notebookrunner_test.py
+++ b/tests/business/notebookrunner_test.py
@@ -216,7 +216,7 @@ async def test_alert(
                     "text": {
                         "type": "mrkdwn",
                         "text": (
-                            "*Cell*\n`exception.ipynb` cell `ed399c0a` (#2)"
+                            "*Cell*\n`exception.ipynb` cell `ed399c0a` (#1)"
                         ),
                         "verbatim": True,
                     },


### PR DESCRIPTION
Revert the change in 5.0.0 to number non-code and code cells together. The UI in Jupyter lab notebooks numbers only code cells, so we should match.