### PR TITLE
DM-39325: Make max WebSocket message size configurable

### DIFF
--- a/changelog.d/20230522_093320_rra_DM_39325.md
+++ b/changelog.d/20230522_093320_rra_DM_39325.md
@@ -1,0 +1,3 @@
+### New features
+
+- The maximum allowable size for a WebSocket message from the Jupyter lab is now configurable per business and defaults to 10MB instead of 4MB.

--- a/src/mobu/constants.py
+++ b/src/mobu/constants.py
@@ -9,6 +9,7 @@ __all__ = [
     "NOTEBOOK_REPO_BRANCH",
     "TOKEN_LIFETIME",
     "USERNAME_REGEX",
+    "WEBSOCKET_OPEN_TIMEOUT",
 ]
 
 NOTEBOOK_REPO_URL = "https://github.com/lsst-sqre/notebook-demo.git"
@@ -24,13 +25,6 @@ mobu currently has no mechanism for refreshing tokens while running, so this
 should be long enough that mobu will be restarted before the tokens expire.
 An expiration exists primarily to ensure that the tokens don't accumulate
 forever.
-"""
-
-WEBSOCKET_MESSAGE_SIZE_LIMIT = 4 * 1024 * 1024
-"""Largest WebSocket message size allowed from lab (in bytes).
-
-This has to be large enough to hold HTML and image output from executing
-notebook cells, even though we discard that data. Set to `None` for no limit.
 """
 
 WEBSOCKET_OPEN_TIMEOUT = 60

--- a/src/mobu/models/business/nublado.py
+++ b/src/mobu/models/business/nublado.py
@@ -184,6 +184,16 @@ class NubladoBusinessOptions(BusinessOptions):
         example=60,
     )
 
+    max_websocket_message_size: int | None = Field(
+        10 * 1024 * 1024,
+        title="Maximum length of WebSocket message (in bytes)",
+        description=(
+            "This has to be large enough to hold HTML and image output from"
+            " executing notebook cells, even though we discard that data."
+            " Set to `null` for no limit."
+        ),
+    )
+
     spawn_settle_time: int = Field(
         10,
         title="How long to wait before polling spawn progress in seconds",


### PR DESCRIPTION
One of the tutorial notebooks returns messages larger than 4MB. Bump the default size to 10MB, which from some research appears to match the Tornado default limit, and make it configurable per business so that we can tweak it further if necessary.