### PR TITLE
DM-39325: Move cachemachine configuration into business options

### DIFF
--- a/changelog.d/20230522_120303_rra_DM_39325.md
+++ b/changelog.d/20230522_120303_rra_DM_39325.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Configuration of whether to use cachemachine and, if so, what image policy to use is now done at the business level instead of globally. This allows the same mobu instance to test both Nublado v2 and Nublado v3.

--- a/src/mobu/config.py
+++ b/src/mobu/config.py
@@ -2,24 +2,15 @@
 
 from __future__ import annotations
 
-from enum import Enum
 from pathlib import Path
 
 from pydantic import BaseSettings, Field, HttpUrl
 from safir.logging import LogLevel, Profile
 
 __all__ = [
-    "CachemachinePolicy",
     "Configuration",
     "config",
 ]
-
-
-class CachemachinePolicy(Enum):
-    """Policy for what eligible images to retrieve from cachemachine."""
-
-    available = "available"
-    desired = "desired"
 
 
 class Configuration(BaseSettings):
@@ -59,30 +50,6 @@ class Configuration(BaseSettings):
         ),
         env="ENVIRONMENT_URL",
         example="https://data.example.org/",
-    )
-
-    use_cachemachine: bool = Field(
-        True,
-        field="Whether to use cachemachine to look up an image",
-        description=(
-            "Set this to false in environments using the new Nublado lab"
-            " controller."
-        ),
-        env="USE_CACHEMACHINE",
-        example=False,
-    )
-
-    cachemachine_image_policy: CachemachinePolicy = Field(
-        CachemachinePolicy.available,
-        field="Class of cachemachine images to use",
-        description=(
-            "Whether to use the images available on all nodes, or the images"
-            " desired by cachemachine. In instances where image streaming is"
-            " enabled and therefore pulls are fast, ``desired`` is preferred."
-            " The default is ``available``."
-        ),
-        env="CACHEMACHINE_IMAGE_POLICY",
-        example=CachemachinePolicy.desired,
     )
 
     gafaelfawr_token: str | None = Field(

--- a/src/mobu/exceptions.py
+++ b/src/mobu/exceptions.py
@@ -179,7 +179,7 @@ class MobuSlackException(SlackException):
     def __init__(
         self,
         msg: str,
-        user: str,
+        user: str | None = None,
         *,
         started_at: datetime | None = None,
         failed_at: datetime | None = None,
@@ -279,8 +279,8 @@ class NotebookRepositoryError(MobuSlackException):
 class CachemachineError(MobuSlackException):
     """Failed to obtain a valid image list from cachemachine."""
 
-    def __init__(self, msg: str, user: str) -> None:
-        super().__init__(user, f"Cachemachine error: {msg}")
+    def __init__(self, msg: str) -> None:
+        super().__init__(f"Cachemachine error: {msg}")
 
 
 class CodeExecutionError(MobuSlackException):

--- a/src/mobu/models/business/nublado.py
+++ b/src/mobu/models/business/nublado.py
@@ -11,9 +11,24 @@ from pydantic import BaseModel, Field
 from .base import BusinessData, BusinessOptions
 
 __all__ = [
+    "CachemachinePolicy",
     "NubladoBusinessData",
     "NubladoBusinessOptions",
+    "NubladoImage",
+    "NubladoImageByClass",
+    "NubladoImageByReference",
+    "NubladoImageByTag",
+    "NubladoImageClass",
+    "NubladoImageSize",
+    "RunningImage",
 ]
+
+
+class CachemachinePolicy(Enum):
+    """Policy for what eligible images to retrieve from cachemachine."""
+
+    available = "available"
+    desired = "desired"
 
 
 class NubladoImageClass(str, Enum):
@@ -132,6 +147,19 @@ class NubladoImageByTag(NubladoImage):
 class NubladoBusinessOptions(BusinessOptions):
     """Options for any business that runs code in a Nublado lab."""
 
+    cachemachine_image_policy: CachemachinePolicy = Field(
+        CachemachinePolicy.available,
+        field="Class of cachemachine images to use",
+        description=(
+            "Whether to use the images available on all nodes, or the images"
+            " desired by cachemachine. In instances where image streaming is"
+            " enabled and therefore pulls are fast, ``desired`` is preferred."
+            " The default is ``available``. Only used if ``use_cachemachine``"
+            " is true."
+        ),
+        example=CachemachinePolicy.desired,
+    )
+
     delete_lab: bool = Field(
         True,
         title="Whether to delete the lab between iterations",
@@ -211,6 +239,16 @@ class NubladoBusinessOptions(BusinessOptions):
     )
 
     url_prefix: str = Field("/nb/", title="URL prefix for JupyterHub")
+
+    use_cachemachine: bool = Field(
+        True,
+        field="Whether to use cachemachine to look up an image",
+        description=(
+            "Set this to false in environments using the new Nublado lab"
+            " controller."
+        ),
+        example=False,
+    )
 
     working_directory: str | None = Field(
         None,

--- a/src/mobu/services/business/nublado.py
+++ b/src/mobu/services/business/nublado.py
@@ -23,6 +23,7 @@ from ...models.business.nublado import (
     RunningImage,
 )
 from ...models.user import AuthenticatedUser
+from ...storage.cachemachine import CachemachineClient
 from ...storage.jupyter import JupyterClient, JupyterLabSession
 from .base import Business
 
@@ -107,9 +108,20 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
         if not config.environment_url:
             raise RuntimeError("environment_url not set")
         environment_url = str(config.environment_url).rstrip("/")
+        cachemachine = None
+        if options.use_cachemachine:
+            if not config.gafaelfawr_token:
+                raise RuntimeError("GAFAELFAWR_TOKEN not set")
+            cachemachine = CachemachineClient(
+                url=environment_url + "/cachemachine/jupyter",
+                token=config.gafaelfawr_token,
+                http_client=http_client,
+                image_policy=options.cachemachine_image_policy,
+            )
         self._client = JupyterClient(
             user=user,
             base_url=environment_url + options.url_prefix,
+            cachemachine=cachemachine,
             logger=logger,
         )
 

--- a/src/mobu/services/business/nublado.py
+++ b/src/mobu/services/business/nublado.py
@@ -247,8 +247,9 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
         self, notebook: str | None = None
     ) -> AsyncIterator[JupyterLabSession]:
         self.logger.info("Creating lab session")
+        opts = {"max_websocket_size": self.options.max_websocket_message_size}
         stopwatch = self.timings.start("create_session", self.annotations())
-        async with self._client.open_lab_session(notebook) as session:
+        async with self._client.open_lab_session(notebook, **opts) as session:
             stopwatch.stop()
             with self.timings.start("execute_setup", self.annotations()):
                 await self.setup_session(session)

--- a/src/mobu/services/business/nublado.py
+++ b/src/mobu/services/business/nublado.py
@@ -105,7 +105,6 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
         self._client = JupyterClient(
             user=user,
             url_prefix=options.url_prefix,
-            image_config=options.image,
             logger=logger,
         )
         self._image: RunningImage | None = None
@@ -200,7 +199,7 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
     async def spawn_lab(self) -> bool:
         with self.timings.start("spawn_lab", self.annotations()) as sw:
             timeout = self.options.spawn_timeout
-            await self._client.spawn_lab()
+            await self._client.spawn_lab(self.options.image)
 
             # Pause before using the progress API, since otherwise it may not
             # have attached to the spawner and will not return a full stream

--- a/src/mobu/services/business/nublado.py
+++ b/src/mobu/services/business/nublado.py
@@ -15,6 +15,7 @@ from safir.datetime import current_datetime, format_datetime_for_logging
 from safir.slack.blockkit import SlackException
 from structlog.stdlib import BoundLogger
 
+from ...config import config
 from ...exceptions import JupyterSpawnError, JupyterTimeoutError
 from ...models.business.nublado import (
     NubladoBusinessData,
@@ -102,11 +103,16 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
         logger: BoundLogger,
     ) -> None:
         super().__init__(options, user, http_client, logger)
+
+        if not config.environment_url:
+            raise RuntimeError("environment_url not set")
+        environment_url = str(config.environment_url).rstrip("/")
         self._client = JupyterClient(
             user=user,
-            url_prefix=options.url_prefix,
+            base_url=environment_url + options.url_prefix,
             logger=logger,
         )
+
         self._image: RunningImage | None = None
         self._node: str | None = None
         self._random = SystemRandom()

--- a/src/mobu/storage/jupyter.py
+++ b/src/mobu/storage/jupyter.py
@@ -402,7 +402,7 @@ class JupyterLabSession:
 
         # Analyse the message type to figure out what to do with the response.
         msg_type = data["msg_type"]
-        if msg_type in ("execute_input", "status"):
+        if msg_type in ("display_data", "execute_input", "status"):
             return None
         elif msg_type == "stream":
             return JupyterOutput(content=data["content"]["text"])

--- a/tests/business/jupyterpythonloop_test.py
+++ b/tests/business/jupyterpythonloop_test.py
@@ -840,94 +840,93 @@ async def test_lab_controller(
     client: AsyncClient, jupyter: MockJupyter, respx_mock: respx.Router
 ) -> None:
     mock_gafaelfawr(respx_mock)
-    config.use_cachemachine = False
 
-    try:
-        # Image by reference.
-        r = await client.put(
-            "/mobu/flocks",
-            json={
-                "name": "test",
-                "count": 1,
-                "users": [{"username": "testuser"}],
-                "scopes": ["exec:notebook"],
-                "business": {
-                    "type": "JupyterPythonLoop",
-                    "options": {
-                        "image": {
-                            "image_class": "by-reference",
-                            "reference": (
-                                "registry.hub.docker.com/lsstsqre/sciplat-lab"
-                                ":d_2021_08_30"
-                            ),
-                        },
+    # Image by reference.
+    r = await client.put(
+        "/mobu/flocks",
+        json={
+            "name": "test",
+            "count": 1,
+            "users": [{"username": "testuser"}],
+            "scopes": ["exec:notebook"],
+            "business": {
+                "type": "JupyterPythonLoop",
+                "options": {
+                    "image": {
+                        "image_class": "by-reference",
+                        "reference": (
+                            "registry.hub.docker.com/lsstsqre/sciplat-lab"
+                            ":d_2021_08_30"
+                        ),
                     },
+                    "use_cachemachine": False,
                 },
             },
-        )
-        assert r.status_code == 201
-        assert jupyter.lab_form["testuser"] == {
-            "image_list": (
-                "registry.hub.docker.com/lsstsqre/sciplat-lab:d_2021_08_30"
-            ),
-            "size": "Large",
-        }
-        r = await client.delete(r.headers["Location"])
-        assert r.status_code == 204
+        },
+    )
+    assert r.status_code == 201
+    assert jupyter.lab_form["testuser"] == {
+        "image_list": (
+            "registry.hub.docker.com/lsstsqre/sciplat-lab:d_2021_08_30"
+        ),
+        "size": "Large",
+    }
+    r = await client.delete(r.headers["Location"])
+    assert r.status_code == 204
 
-        # Image by class.
-        r = await client.put(
-            "/mobu/flocks",
-            json={
-                "name": "test",
-                "count": 1,
-                "users": [{"username": "testuser"}],
-                "scopes": ["exec:notebook"],
-                "business": {
-                    "type": "JupyterPythonLoop",
-                    "options": {
-                        "image": {
-                            "image_class": "latest-daily",
-                            "size": "Medium",
-                            "debug": True,
-                        },
+    # Image by class.
+    r = await client.put(
+        "/mobu/flocks",
+        json={
+            "name": "test",
+            "count": 1,
+            "users": [{"username": "testuser"}],
+            "scopes": ["exec:notebook"],
+            "business": {
+                "type": "JupyterPythonLoop",
+                "options": {
+                    "image": {
+                        "image_class": "latest-daily",
+                        "size": "Medium",
+                        "debug": True,
                     },
+                    "use_cachemachine": False,
                 },
             },
-        )
-        assert r.status_code == 201
-        assert jupyter.lab_form["testuser"] == {
-            "enable_debug": "true",
-            "image_class": "latest-daily",
-            "size": "Medium",
-        }
-        r = await client.delete(r.headers["Location"])
-        assert r.status_code == 204
+        },
+    )
+    assert r.status_code == 201
+    assert jupyter.lab_form["testuser"] == {
+        "enable_debug": "true",
+        "image_class": "latest-daily",
+        "size": "Medium",
+    }
+    r = await client.delete(r.headers["Location"])
+    assert r.status_code == 204
 
-        # Image by tag.
-        r = await client.put(
-            "/mobu/flocks",
-            json={
-                "name": "test",
-                "count": 1,
-                "users": [{"username": "testuser"}],
-                "scopes": ["exec:notebook"],
-                "business": {
-                    "type": "JupyterPythonLoop",
-                    "options": {
-                        "image": {
-                            "image_class": "by-tag",
-                            "tag": "w_2077_44",
-                            "size": "Small",
-                        },
+    # Image by tag.
+    r = await client.put(
+        "/mobu/flocks",
+        json={
+            "name": "test",
+            "count": 1,
+            "users": [{"username": "testuser"}],
+            "scopes": ["exec:notebook"],
+            "business": {
+                "type": "JupyterPythonLoop",
+                "options": {
+                    "image": {
+                        "image_class": "by-tag",
+                        "tag": "w_2077_44",
+                        "size": "Small",
                     },
+                    "use_cachemachine": False,
                 },
             },
-        )
-        assert r.status_code == 201
-        assert jupyter.lab_form["testuser"] == {
-            "image_tag": "w_2077_44",
-            "size": "Small",
-        }
-    finally:
-        config.use_cachemachine = True
+        },
+    )
+    assert r.status_code == 201
+    assert jupyter.lab_form["testuser"] == {
+        "image_tag": "w_2077_44",
+        "size": "Small",
+    }


### PR DESCRIPTION
Allow use of cachemachine and the cachemachine image policy are now configurable in the business options rather than globally.

Restructure code and options to move more things out of the JupyterClient class into the business logic to allow JupyterClient to more easily be moved into Safir, including managing the cachemachine client construction.

Fix passing the maximum WebSocket size into JupyterClient, missed in the previous PR.

Ignore WebSocket messages of type `display_data`, since those are not interesting to us.