### PR TITLE
DM-39325: Fix stripping of ANSI escapes in Slack messages

### DIFF
--- a/changelog.d/20230522_163207_rra_DM_39325.md
+++ b/changelog.d/20230522_163207_rra_DM_39325.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- When reporting errors to Slack, mobu 5.0.0 mistakenly started stripping ANSI escape sequences from the code being executed, which should be safe since it comes from local notebooks or configuration, instead of the error output, which is where Jupyter labs like to add formatting. Strip ANSI escape sequences from the error output instead of the code.

--- a/src/mobu/exceptions.py
+++ b/src/mobu/exceptions.py
@@ -312,13 +312,13 @@ class CodeExecutionError(MobuSlackException):
             if self.status:
                 msg += f" (status: {self.status})"
             if self.code:
-                msg += f"\nCode: {_remove_ansi_escapes(self.code)}"
+                msg += f"\nCode: {self.code}"
         elif self.code:
-            code = _remove_ansi_escapes(self.code)
-            msg = f"{self.user}: running {self.code_type} '{code}' failed"
+            msg = f"{self.user}: running {self.code_type} '{self.code}' failed"
         else:
             msg = f"{self.user}: running {self.code_type} failed"
-        msg += f"\nError: {self.error}"
+        if self.error:
+            msg += f"\nError: {_remove_ansi_escapes(self.error)}"
         return msg
 
     def to_slack(self) -> SlackMessage:
@@ -333,11 +333,13 @@ class CodeExecutionError(MobuSlackException):
 
         attachments: list[SlackBaseBlock] = []
         if self.error:
-            attachment = SlackCodeBlock(heading="Error", code=self.error)
+            error = _remove_ansi_escapes(self.error)
+            attachment = SlackCodeBlock(heading="Error", code=error)
             attachments.append(attachment)
         if self.code:
-            code = _remove_ansi_escapes(self.code)
-            attachment = SlackCodeBlock(heading="Code executed", code=code)
+            attachment = SlackCodeBlock(
+                heading="Code executed", code=self.code
+            )
             attachments.append(attachment)
 
         return SlackMessage(


### PR DESCRIPTION
When reporting errors to Slack, mobu 5.0.0 mistakenly started stripping ANSI escape sequences from the code being executed, which should be safe since it comes from local notebooks or configuration, instead of the error output, which is where Jupyter labs like to add formatting. Strip ANSI escape sequences from the error output instead of the code.