### PR TITLE
DM-39360: Fix timeout reporting opening WebSocket

### DIFF
--- a/changelog.d/20230526_123621_rra_DM_39360.md
+++ b/changelog.d/20230526_123621_rra_DM_39360.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix reporting of WebSocket open timeouts to Slack.

--- a/src/mobu/storage/jupyter.py
+++ b/src/mobu/storage/jupyter.py
@@ -266,6 +266,7 @@ class JupyterLabSession:
             raise JupyterWebSocketError.from_exception(e, user) from e
         except TimeoutError as e:
             msg = "Timed out attempting to open WebSocket to lab session"
+            user = self._username
             raise JupyterTimeoutError(msg, user, started_at=start) from e
         return self
 


### PR DESCRIPTION
If there was a timeout while opening a WebSocket to the lab, mobu failed with an unbound variable exception. Add an assignment to fix that problem.