### PR TITLE
DM-39360: Make Jupyter client timeout configurable

### DIFF
--- a/changelog.d/20230531_121107_rra_DM_39360.md
+++ b/changelog.d/20230531_121107_rra_DM_39360.md
@@ -1,0 +1,3 @@
+### New features
+
+- The timeout when talking to JupyterHub and Jupyter labs can now be configured in the business options (as ``jupyter_timeout``). The default is now 60s instead of 30s.

--- a/src/mobu/models/business/nublado.py
+++ b/src/mobu/models/business/nublado.py
@@ -212,6 +212,15 @@ class NubladoBusinessOptions(BusinessOptions):
         example=60,
     )
 
+    jupyter_timeout: int = Field(
+        60,
+        title="HTTP client timeout for Jupyter requests",
+        description=(
+            "Used as the connect, read, and write timeout for talking to"
+            " either JupyterHub or Jupyter lab."
+        ),
+    )
+
     max_websocket_message_size: int | None = Field(
         10 * 1024 * 1024,
         title="Maximum length of WebSocket message (in bytes)",

--- a/src/mobu/services/business/nublado.py
+++ b/src/mobu/services/business/nublado.py
@@ -123,6 +123,7 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
             base_url=environment_url + options.url_prefix,
             cachemachine=cachemachine,
             logger=logger,
+            timeout=options.jupyter_timeout,
         )
 
         self._image: RunningImage | None = None

--- a/src/mobu/storage/jupyter.py
+++ b/src/mobu/storage/jupyter.py
@@ -533,6 +533,10 @@ class JupyterClient:
         posted directly to JupyterHub.
     logger
         Logger to use.
+    timeout
+        Timeout to use when talking to JupyterHub and Jupyter lab. This is
+        used as a connection, read, and write timeout for all regular HTTP
+        calls.
 
     Notes
     -----
@@ -549,6 +553,7 @@ class JupyterClient:
         base_url: str,
         cachemachine: CachemachineClient | None = None,
         logger: BoundLogger,
+        timeout: int = 30,
     ) -> None:
         self.user = user
         self._base_url = base_url
@@ -575,7 +580,7 @@ class JupyterClient:
             headers=headers,
             cookies=cookies,
             follow_redirects=True,
-            timeout=30.0,  # default is 5, but JupyterHub can be slow
+            timeout=timeout,
         )
 
     async def close(self) -> None:


### PR DESCRIPTION
Allow configuration of the timeout used when talking to JupyterHub and Jupyter labs, and increase the default to 60s since we're seeing a fair number of possibly spurious timeouts in production.