### PR TITLE
DM-39552: Ignore comm messages from the lab

### DIFF
--- a/src/mobu/storage/jupyter.py
+++ b/src/mobu/storage/jupyter.py
@@ -161,6 +161,9 @@ class JupyterLabSession:
     """
 
     _IGNORED_MESSAGE_TYPES = (
+        "comm_close",
+        "comm_msg",
+        "comm_open",
         "display_data",
         "execute_input",
         "execute_result",


### PR DESCRIPTION
Comm messages are a custom messaging protocol used by the lab to talk to extensions running in the browser. They should be ignored by mobu.