### PR TITLE
DM-39552: Catch exceptions while sending to the WebSocket

### DIFF
--- a/changelog.d/20230605_092121_rra_DM_39552.md
+++ b/changelog.d/20230605_092121_rra_DM_39552.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Improve error reporting by catching exceptions thrown while sending code to the lab WebSocket for execution.

--- a/src/mobu/storage/jupyter.py
+++ b/src/mobu/storage/jupyter.py
@@ -355,11 +355,11 @@ class JupyterLabSession:
             "metadata": {},
             "buffers": {},
         }
-        await self._socket.send(json.dumps(request))
 
-        # Consume messages waiting for the response.
+        # Send the message and consume messages waiting for the response.
         result = ""
         try:
+            await self._socket.send(json.dumps(request))
             async for message in self._socket:
                 try:
                     output = self._parse_message(message, message_id)


### PR DESCRIPTION
The send to the WebSocket was mistakenly outside of the try/except block for catching WebSocket exceptions. Move it inside the block for improved error reporting.