### PR TITLE
DM-39552: Generate less data when summarizing flocks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,8 @@ repos:
       - id: check-yaml
       - id: check-toml
 
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.272
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.0.277
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: black
 
-  - repo: https://github.com/asottile/blacken-docs
+  - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.14.0
     hooks:
       - id: blacken-docs

--- a/changelog.d/20230706_111300_rra_DM_39552.md
+++ b/changelog.d/20230706_111300_rra_DM_39552.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Rather than dumping the full monkey data when summarizing flocks, which can cause long enough delays that in-progress calls fail due to the huge amount of timing data, extract only the success and failure count from the running business. This should be considerably faster and avoid timeout problems.

--- a/src/mobu/models/business/nublado.py
+++ b/src/mobu/models/business/nublado.py
@@ -34,6 +34,8 @@ class CachemachinePolicy(Enum):
 class NubladoImageClass(str, Enum):
     """Possible ways of selecting an image."""
 
+    __slots__ = ()
+
     RECOMMENDED = "recommended"
     LATEST_RELEASE = "latest-release"
     LATEST_WEEKLY = "latest-weekly"

--- a/src/mobu/services/flock.py
+++ b/src/mobu/services/flock.py
@@ -96,10 +96,9 @@ class Flock:
         successes = 0
         failures = 0
         for monkey in self._monkeys.values():
-            data = monkey.dump()
             count += 1
-            successes += data.business.success_count
-            failures += data.business.failure_count
+            successes += monkey.business.success_count
+            failures += monkey.business.failure_count
         return FlockSummary(
             name=self.name,
             business=self._config.business.type,


### PR DESCRIPTION
Previously, to generate a flock summary, mobu first converted all information about the running monkeys to output data structures and then added up success and failure counts from those. Because of the huge amount of timing data that mobu gathers, this took long enough (and is not async, so it blocks everything else) that other in-progress calls timed out. It also meant that the summary end point appeared to hang.

Avoid this by reading the success and failure counts directly from the running monkey business, avoiding the need to dump and thus convert their data. This is a temporary fix until the way that timing data is stored can be overhauled.