### PR TITLE
Add option to use query lists in values config in TAPQueryRunner (Options)

### DIFF
--- a/src/mobu/models/business/tapqueryrunner.py
+++ b/src/mobu/models/business/tapqueryrunner.py
@@ -34,13 +34,18 @@ class TAPQueryRunnerOptions(BusinessOptions):
         example=True,
     )
 
+    queries: list | None = Field(
+        None,
+        title="Which query list to use for the TapQueryRunner",
+        description="List of queries to be run instead of a query_set",
+        example=True,
+    )
+
 
 class TAPQueryRunnerConfig(BusinessConfig):
     """Configuration specialization for TAPQueryRunner."""
 
-    type: Literal["TAPQueryRunner"] = Field(
-        ..., title="Type of business to run"
-    )
+    type: Literal["TAPQueryRunner"] = Field(..., title="Type of business to run")
 
     options: TAPQueryRunnerOptions = Field(
         default_factory=TAPQueryRunnerOptions,

--- a/tests/business/tapqueryrunner_test.py
+++ b/tests/business/tapqueryrunner_test.py
@@ -213,10 +213,7 @@ async def test_alert(
                             "type": "section",
                             "text": {
                                 "type": "mrkdwn",
-                                "text": (
-                                    "*Error*\n"
-                                    "```\nException: some error\n```"
-                                ),
+                                "text": ("*Error*\n" "```\nException: some error\n```"),
                                 "verbatim": True,
                             },
                         },
@@ -263,3 +260,19 @@ async def test_random_object() -> None:
         assert len(random_objects) == 12
         for obj in random_objects:
             assert obj in objects
+
+
+@pytest.mark.asyncio
+async def test_query_list() -> None:
+    queries = [
+        "SELECT TOP 10 * FROM TAP_SCHEMA.tables",
+        "SELECT TOP 10 * FROM TAP_SCHEMA.columns",
+    ]
+    user = AuthenticatedUser(username="user", scopes=["read:tap"], token="blah blah")
+    logger = structlog.get_logger(__file__)
+    options = TAPQueryRunnerOptions(queries=queries)
+    http_client = await http_client_dependency()
+    with patch.object(pyvo.dal, "TAPService"):
+        runner = TAPQueryRunner(options, user, http_client, logger)
+    generated_query = runner.get_next_query()
+    assert generated_query in queries


### PR DESCRIPTION
Changes introduce a way of defining queries to be executed by a Mobu TAP Test run in the configuration. Specifically, with the changes an RSP maintainer can specify the queries in the following way (or use the existing query_set option to use a local filepath / template):

```
config:
  autostart:
    - name: "tap"
      count: 1
      users:
	- username: "bot-mobu-tap"
	  uidnumber: 74775
	  gidnumber: 74775
      scopes: ["read:tap"]
      business:
	type: "TAPQueryRunner"
	restart: true
	options:
	  sync: true
	  queries: 
	    - "SELECT TOP 10 * FROM TAP_SCHEMA.schemas"
	    - "SELECT TOP 10 * FROM MYDB.MyTable"
```

Changes include a couple more minor changes where my formatter thought the length of a line was too long, this can be excluded from the PR if you think they don't need to be included. Also one more test added, thought it could use a few more to improve coverage.

Let me know if you'd like any of the changes modified / removed, as this was a first attempt to get this working, but I'm not sure if it fits with your initial designs and/or if the naming of the methods/classes match what the code is doing. 