### PR TITLE
DM-42182: Switch to Ruff for reformatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,15 +11,11 @@ repos:
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
-
-  - repo: https://github.com/psf/black
-    rev: 23.11.0
-    hooks:
-      - id: black
+      - id: ruff-format
 
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.16.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==23.3.0]
+        additional_dependencies: [black==23.10.1]
         args: [-l, '79', -t, py311]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,35 +125,67 @@ ignore = [
     "ANN401",  # sometimes Any is the right type
     "ARG001",  # unused function arguments are often legitimate
     "ARG002",  # unused method arguments are often legitimate
+    "ARG005",  # unused lambda arguments are often legitimate
     "BLE001",  # we want to catch and report Exception in background tasks
+    "C414",    # nested sorted is how you sort by multiple keys with reverse
     "COM812",  # omitting trailing commas allows black autoreformatting
     "D102",    # sometimes we use docstring inheritence
     "D104",    # don't see the point of documenting every package
     "D105",    # our style doesn't require docstrings for magic methods
     "D106",    # Pydantic uses a nested Config class that doesn't warrant docs
+    "D205",    # our documentation style allows a folded first line
     "EM101",   # justification (duplicate string in traceback) is silly
     "EM102",   # justification (duplicate string in traceback) is silly
     "FBT003",  # positional booleans are normal for Pydantic field defaults
+    "FIX002",  # point of a TODO comment is that we're not ready to fix it
     "G004",    # forbidding logging f-strings is appealing, but not our style
     "RET505",  # disagree that omitting else always makes code more readable
+    "PLR0911", # often many returns is clearer and simpler style
     "PLR0913", # factory pattern uses constructors with many arguments
     "PLR2004", # too aggressive about magic values
+    "PLW0603", # yes global is discouraged but if needed, it's needed
+    "S105",    # good idea but too many false positives on non-passwords
+    "S106",    # good idea but too many false positives on non-passwords
+    "S107",    # good idea but too many false positives on non-passwords
+    "S603",    # not going to manually mark every subprocess call as reviewed
+    "S607",    # using PATH is not a security vulnerability
     "SIM102",  # sometimes the formatting of nested if statements is clearer
     "SIM117",  # sometimes nested with contexts are clearer
     "TCH001",  # we decided to not maintain separate TYPE_CHECKING blocks
     "TCH002",  # we decided to not maintain separate TYPE_CHECKING blocks
     "TCH003",  # we decided to not maintain separate TYPE_CHECKING blocks
+    "TD003",   # we don't require issues be created for TODOs
     "TID252",  # if we're going to use relative imports, use them always
     "TRY003",  # good general advice but lint is way too aggressive
+    "TRY301",  # sometimes raising exceptions inside try is the best flow
+
+    # The following settings should be disabled when using ruff format
+    # per https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D300",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "COM812",
+    "COM819",
+    "ISC001",
+    "ISC002",
 ]
 select = ["ALL"]
-target-version = "py311"
+target-version = "py312"
 
 [tool.ruff.per-file-ignores]
 "src/mobu/handlers/**" = [
     "D103",    # FastAPI handlers should not have docstrings
 ]
 "tests/**" = [
+    "C901",    # tests are allowed to be complex, sometimes that's convenient
+    "D101",    # tests don't need docstrings
     "D103",    # tests don't need docstrings
     "PLR0915", # tests are allowed to be long, sometimes that's convenient
     "PT012",   # way too aggressive about limiting pytest.raises blocks
@@ -187,12 +219,6 @@ builtins-ignorelist = [
 [tool.ruff.flake8-pytest-style]
 fixture-parentheses = false
 mark-parentheses = false
-
-[tool.ruff.pep8-naming]
-classmethod-decorators = [
-    "pydantic.root_validator",
-    "pydantic.validator",
-]
 
 [tool.ruff.pydocstyle]
 convention = "numpy"

--- a/src/mobu/storage/jupyter.py
+++ b/src/mobu/storage/jupyter.py
@@ -474,7 +474,7 @@ class JupyterLabSession:
 
 
 def _convert_exception(
-    f: Callable[Concatenate[JupyterClient, P], Coroutine[None, None, T]]
+    f: Callable[Concatenate[JupyterClient, P], Coroutine[None, None, T]],
 ) -> Callable[Concatenate[JupyterClient, P], Coroutine[None, None, T]]:
     """Convert web errors to a `~mobu.exceptions.JupyterWebError`.
 
@@ -497,7 +497,7 @@ def _convert_exception(
 
 
 def _convert_iterator_exception(
-    f: Callable[Concatenate[JupyterClient, P], AsyncIterator[T]]
+    f: Callable[Concatenate[JupyterClient, P], AsyncIterator[T]],
 ) -> Callable[Concatenate[JupyterClient, P], AsyncIterator[T]]:
     """Convert web errors to a `~mobu.exceptions.JupyterWebError`.
 


### PR DESCRIPTION
Use Ruff instead of Black to reformat code, although continue to use blacken-docs for documentation since Ruff does not yet have an equivalent. Merge Ruff exclusions with Nublado and drop settings no longer required with Pydantic v2.