### PR TITLE
DM-42182: Change some JupyterHub terminology to Nublado

### DIFF
--- a/changelog.d/20231215_141606_rra.md
+++ b/changelog.d/20231215_141606_rra.md
@@ -1,0 +1,3 @@
+### Backwards-incompatible changes
+
+- Rename `JupyterPythonLoop` to `NubladoPythonLoop` to make it explicit that it requires Nublado and will not work with an arbitrary JupyterHub.

--- a/scripts/install-dependency-packages.sh
+++ b/scripts/install-dependency-packages.sh
@@ -22,8 +22,7 @@ export DEBIAN_FRONTEND=noninteractive
 # Update the package listing, so we know what packages exist.
 apt-get update
 
-# Install various dependencies that may be required to install JupyterHub or
-# our add-on modules, or are wanted at runtime:
+# Install various dependencies that may be required to install mobu:
 #
 # build-essential: sometimes needed to build Python modules
 # git: required by setuptools_scm

--- a/src/mobu/exceptions.py
+++ b/src/mobu/exceptions.py
@@ -418,7 +418,7 @@ class JupyterTimeoutError(MobuSlackException):
 
 
 class JupyterWebError(MobuSlackWebException):
-    """An error occurred when talking to JupyterHub or JupyterLab."""
+    """An error occurred when talking to JupyterHub or a Jupyter lab."""
 
 
 class JupyterWebSocketError(MobuSlackException):

--- a/src/mobu/models/business/nublado.py
+++ b/src/mobu/models/business/nublado.py
@@ -79,11 +79,11 @@ class NubladoImage(BaseModel, metaclass=ABCMeta):
 
     @abstractmethod
     def to_spawn_form(self) -> dict[str, str]:
-        """Convert to data suitable for posting to JupyterHub's spawn form.
+        """Convert to data suitable for posting to Nublado's spawn form.
 
         Returns
         -------
-        dict of str to str
+        dict of str
             Post data to send to the JupyterHub spawn page.
         """
 
@@ -167,8 +167,8 @@ class NubladoBusinessOptions(BusinessOptions):
         title="Whether to delete the lab between iterations",
         description=(
             "By default, the lab is deleted and recreated after each"
-            " iteration of monkey business involving JupyterLab. Set this"
-            " to False to keep the same lab."
+            " iteration of monkey business. Set this to false to keep the"
+            " same lab."
         ),
         examples=[True],
     )
@@ -180,7 +180,7 @@ class NubladoBusinessOptions(BusinessOptions):
     execution_idle_time: int = Field(
         1,
         title="How long to wait between cell executions in seconds",
-        description="Used by JupyterPythonLoop and NotebookRunner",
+        description="Used by NubladoPythonLoop and NotebookRunner",
         examples=[1],
     )
 
@@ -188,9 +188,8 @@ class NubladoBusinessOptions(BusinessOptions):
         True,
         title="Whether to get the node name for error reporting",
         description=(
-            "Used by JupyterPythonLoop and its subclasses. Requires the lab"
-            " have rubin_jupyter_utils.lab.notebook.utils pre-installed and"
-            " able to make Kubernetes API calls."
+            "Used by NubladoPythonLoop and its subclasses. Requires the lab"
+            " have lsst.rsp pre-installed."
         ),
     )
 
@@ -269,7 +268,7 @@ class NubladoBusinessOptions(BusinessOptions):
 
 
 class RunningImage(BaseModel):
-    """Information about the running JupyterLab image."""
+    """Information about the running Jupyter lab image."""
 
     reference: str | None = Field(
         None,
@@ -287,6 +286,6 @@ class NubladoBusinessData(BusinessData):
 
     image: RunningImage | None = Field(
         None,
-        title="JupyterLab image information",
+        title="Jupyter lab image information",
         description="Will only be present when there is an active Jupyter lab",
     )

--- a/src/mobu/models/business/nubladopythonloop.py
+++ b/src/mobu/models/business/nubladopythonloop.py
@@ -1,4 +1,4 @@
-"""Models for the JupyterPythonLoop monkey business."""
+"""Models for the NubladoPythonLoop monkey business."""
 
 from __future__ import annotations
 
@@ -10,13 +10,13 @@ from .base import BusinessConfig
 from .nublado import NubladoBusinessOptions
 
 __all__ = [
-    "JupyterPythonLoopConfig",
-    "JupyterPythonLoopOptions",
+    "NubladoPythonLoopConfig",
+    "NubladoPythonLoopOptions",
 ]
 
 
-class JupyterPythonLoopOptions(NubladoBusinessOptions):
-    """Options for JupyterPythonLoop monkey business."""
+class NubladoPythonLoopOptions(NubladoBusinessOptions):
+    """Options for NubladoPythonLoop monkey business."""
 
     code: str = Field(
         'print(2+2, end="")',
@@ -35,14 +35,14 @@ class JupyterPythonLoopOptions(NubladoBusinessOptions):
     )
 
 
-class JupyterPythonLoopConfig(BusinessConfig):
-    """Configuration specialization for JupyterPythonLoop."""
+class NubladoPythonLoopConfig(BusinessConfig):
+    """Configuration specialization for NubladoPythonLoop."""
 
-    type: Literal["JupyterPythonLoop"] = Field(
+    type: Literal["NubladoPythonLoop"] = Field(
         ..., title="Type of business to run"
     )
 
-    options: JupyterPythonLoopOptions = Field(
-        default_factory=JupyterPythonLoopOptions,
+    options: NubladoPythonLoopOptions = Field(
+        default_factory=NubladoPythonLoopOptions,
         title="Options for the monkey business",
     )

--- a/src/mobu/models/flock.py
+++ b/src/mobu/models/flock.py
@@ -6,8 +6,8 @@ from typing import Self
 from pydantic import BaseModel, Field, model_validator
 
 from .business.empty import EmptyLoopConfig
-from .business.jupyterpythonloop import JupyterPythonLoopConfig
 from .business.notebookrunner import NotebookRunnerConfig
+from .business.nubladopythonloop import NubladoPythonLoopConfig
 from .business.tapqueryrunner import TAPQueryRunnerConfig
 from .business.tapquerysetrunner import TAPQuerySetRunnerConfig
 from .monkey import MonkeyData
@@ -52,7 +52,7 @@ class FlockConfig(BaseModel):
         TAPQueryRunnerConfig
         | TAPQuerySetRunnerConfig
         | NotebookRunnerConfig
-        | JupyterPythonLoopConfig
+        | NubladoPythonLoopConfig
         | EmptyLoopConfig
     ) = Field(..., title="Business to run")
 

--- a/src/mobu/models/solitary.py
+++ b/src/mobu/models/solitary.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from pydantic import BaseModel, Field
 
 from .business.empty import EmptyLoopConfig
-from .business.jupyterpythonloop import JupyterPythonLoopConfig
 from .business.notebookrunner import NotebookRunnerConfig
+from .business.nubladopythonloop import NubladoPythonLoopConfig
 from .business.tapqueryrunner import TAPQueryRunnerConfig
 from .user import User
 
@@ -30,7 +30,7 @@ class SolitaryConfig(BaseModel):
     business: (
         TAPQueryRunnerConfig
         | NotebookRunnerConfig
-        | JupyterPythonLoopConfig
+        | NubladoPythonLoopConfig
         | EmptyLoopConfig
     ) = Field(..., title="Business to run")
 

--- a/src/mobu/services/business/notebookrunner.py
+++ b/src/mobu/services/business/notebookrunner.py
@@ -24,7 +24,7 @@ from ...models.business.notebookrunner import (
     NotebookRunnerOptions,
 )
 from ...models.user import AuthenticatedUser
-from ...storage.jupyter import JupyterLabSession
+from ...storage.nublado import JupyterLabSession
 from .nublado import NubladoBusiness
 
 __all__ = ["NotebookRunner"]

--- a/src/mobu/services/business/nublado.py
+++ b/src/mobu/services/business/nublado.py
@@ -24,7 +24,7 @@ from ...models.business.nublado import (
 )
 from ...models.user import AuthenticatedUser
 from ...storage.cachemachine import CachemachineClient
-from ...storage.jupyter import JupyterClient, JupyterLabSession
+from ...storage.nublado import JupyterLabSession, NubladoClient
 from .base import Business
 
 T = TypeVar("T", bound="NubladoBusinessOptions")
@@ -118,7 +118,7 @@ class NubladoBusiness(Business, Generic[T], metaclass=ABCMeta):
                 http_client=http_client,
                 image_policy=options.cachemachine_image_policy,
             )
-        self._client = JupyterClient(
+        self._client = NubladoClient(
             user=user,
             base_url=environment_url + options.url_prefix,
             cachemachine=cachemachine,

--- a/src/mobu/services/business/nubladopythonloop.py
+++ b/src/mobu/services/business/nubladopythonloop.py
@@ -1,4 +1,4 @@
-"""JupyterPythonLoop logic for mobu.
+"""NubladoPythonLoop logic for mobu.
 
 This business pattern will start a lab and run some code in a loop over and
 over again.
@@ -9,15 +9,15 @@ from __future__ import annotations
 from httpx import AsyncClient
 from structlog.stdlib import BoundLogger
 
-from ...models.business.jupyterpythonloop import JupyterPythonLoopOptions
+from ...models.business.nubladopythonloop import NubladoPythonLoopOptions
 from ...models.user import AuthenticatedUser
-from ...storage.jupyter import JupyterLabSession
+from ...storage.nublado import JupyterLabSession
 from .nublado import NubladoBusiness
 
-__all__ = ["JupyterPythonLoop"]
+__all__ = ["NubladoPythonLoop"]
 
 
-class JupyterPythonLoop(NubladoBusiness):
+class NubladoPythonLoop(NubladoBusiness):
     """Run simple Python code in a loop inside a lab kernel.
 
     Parameters
@@ -34,7 +34,7 @@ class JupyterPythonLoop(NubladoBusiness):
 
     def __init__(
         self,
-        options: JupyterPythonLoopOptions,
+        options: NubladoPythonLoopOptions,
         user: AuthenticatedUser,
         http_client: AsyncClient,
         logger: BoundLogger,

--- a/src/mobu/services/monkey.py
+++ b/src/mobu/services/monkey.py
@@ -19,16 +19,16 @@ from ..config import config
 from ..exceptions import MobuSlackException
 from ..models.business.base import BusinessConfig
 from ..models.business.empty import EmptyLoopConfig
-from ..models.business.jupyterpythonloop import JupyterPythonLoopConfig
 from ..models.business.notebookrunner import NotebookRunnerConfig
+from ..models.business.nubladopythonloop import NubladoPythonLoopConfig
 from ..models.business.tapqueryrunner import TAPQueryRunnerConfig
 from ..models.business.tapquerysetrunner import TAPQuerySetRunnerConfig
 from ..models.monkey import MonkeyData, MonkeyState
 from ..models.user import AuthenticatedUser
 from .business.base import Business
 from .business.empty import EmptyLoop
-from .business.jupyterpythonloop import JupyterPythonLoop
 from .business.notebookrunner import NotebookRunner
+from .business.nubladopythonloop import NubladoPythonLoop
 from .business.tapqueryrunner import TAPQueryRunner
 from .business.tapquerysetrunner import TAPQuerySetRunner
 
@@ -89,8 +89,8 @@ class Monkey:
             self.business = EmptyLoop(
                 business_config.options, user, self._http_client, self._logger
             )
-        elif isinstance(business_config, JupyterPythonLoopConfig):
-            self.business = JupyterPythonLoop(
+        elif isinstance(business_config, NubladoPythonLoopConfig):
+            self.business = NubladoPythonLoop(
                 business_config.options, user, self._http_client, self._logger
             )
         elif isinstance(business_config, NotebookRunnerConfig):

--- a/src/mobu/storage/nublado.py
+++ b/src/mobu/storage/nublado.py
@@ -1,7 +1,7 @@
-"""AsyncIO client for communicating with Jupyter.
+"""AsyncIO client for communicating with Jupyter using Nublado.
 
-Allows the caller to login to the hub, spawn lab containers, and then run
-jupyter kernels remotely.
+Allows the caller to login to JupyterHub, spawn lab containers, and then run
+Jupyter kernels remotely.
 """
 
 from __future__ import annotations
@@ -46,7 +46,7 @@ from .cachemachine import CachemachineClient, JupyterCachemachineImage
 P = ParamSpec("P")
 T = TypeVar("T")
 
-__all__ = ["JupyterClient", "JupyterLabSession"]
+__all__ = ["NubladoClient", "JupyterLabSession"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -139,7 +139,7 @@ class JupyterLabSession:
 
     A context manager providing an open WebSocket session. The session will be
     automatically deleted when exiting the context manager. Objects of this
-    type should be created by calling `JupyterClient.open_lab_session`.
+    type should be created by calling `NubladoClient.open_lab_session`.
 
     Parameters
     ----------
@@ -474,8 +474,8 @@ class JupyterLabSession:
 
 
 def _convert_exception(
-    f: Callable[Concatenate[JupyterClient, P], Coroutine[None, None, T]],
-) -> Callable[Concatenate[JupyterClient, P], Coroutine[None, None, T]]:
+    f: Callable[Concatenate[NubladoClient, P], Coroutine[None, None, T]],
+) -> Callable[Concatenate[NubladoClient, P], Coroutine[None, None, T]]:
     """Convert web errors to a `~mobu.exceptions.JupyterWebError`.
 
     This can only be used as a decorator on `JupyterClientSession` or another
@@ -485,7 +485,7 @@ def _convert_exception(
 
     @wraps(f)
     async def wrapper(
-        client: JupyterClient, *args: P.args, **kwargs: P.kwargs
+        client: NubladoClient, *args: P.args, **kwargs: P.kwargs
     ) -> T:
         try:
             return await f(client, *args, **kwargs)
@@ -497,8 +497,8 @@ def _convert_exception(
 
 
 def _convert_iterator_exception(
-    f: Callable[Concatenate[JupyterClient, P], AsyncIterator[T]],
-) -> Callable[Concatenate[JupyterClient, P], AsyncIterator[T]]:
+    f: Callable[Concatenate[NubladoClient, P], AsyncIterator[T]],
+) -> Callable[Concatenate[NubladoClient, P], AsyncIterator[T]]:
     """Convert web errors to a `~mobu.exceptions.JupyterWebError`.
 
     This can only be used as a decorator on `JupyterClientSession` or another
@@ -508,7 +508,7 @@ def _convert_iterator_exception(
 
     @wraps(f)
     async def wrapper(
-        client: JupyterClient, *args: P.args, **kwargs: P.kwargs
+        client: NubladoClient, *args: P.args, **kwargs: P.kwargs
     ) -> AsyncIterator[T]:
         try:
             async for result in f(client, *args, **kwargs):
@@ -520,8 +520,8 @@ def _convert_iterator_exception(
     return wrapper
 
 
-class JupyterClient:
-    """Client for talking to JupyterHub and Jupyter labs.
+class NubladoClient:
+    """Client for talking to JupyterHub and Jupyter labs that use Nublado.
 
     Parameters
     ----------

--- a/tests/autostart_test.py
+++ b/tests/autostart_test.py
@@ -36,7 +36,7 @@ AUTOSTART_CONFIG = """
   scopes: ["exec:notebook"]
   restart: true
   business:
-    type: JupyterPythonLoop
+    type: NubladoPythonLoop
     restart: True
     options:
       image:
@@ -118,7 +118,7 @@ async def test_autostart(client: AsyncClient, jupyter: MockJupyter) -> None:
             ],
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "restart": True,
                 "options": {
                     "image": {
@@ -140,7 +140,7 @@ async def test_autostart(client: AsyncClient, jupyter: MockJupyter) -> None:
                             "lighthouse.ceres/library/sketchbook:recommended"
                         ),
                     },
-                    "name": "JupyterPythonLoop",
+                    "name": "NubladoPythonLoop",
                     "success_count": ANY,
                     "timings": ANY,
                 },
@@ -163,7 +163,7 @@ async def test_autostart(client: AsyncClient, jupyter: MockJupyter) -> None:
                             "lighthouse.ceres/library/sketchbook:recommended"
                         ),
                     },
-                    "name": "JupyterPythonLoop",
+                    "name": "NubladoPythonLoop",
                     "success_count": ANY,
                     "timings": ANY,
                 },

--- a/tests/business/nubladopythonloop_test.py
+++ b/tests/business/nubladopythonloop_test.py
@@ -1,4 +1,4 @@
-"""Test the JupyterPythonLoop business logic."""
+"""Test the NubladoPythonLoop business logic."""
 
 from __future__ import annotations
 
@@ -33,7 +33,7 @@ async def test_run(
             "user_spec": {"username_prefix": "testuser", "uid_start": 1000},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {"spawn_settle_time": 0, "max_executions": 3},
             },
         },
@@ -46,7 +46,7 @@ async def test_run(
         "name": "testuser1",
         "business": {
             "failure_count": 0,
-            "name": "JupyterPythonLoop",
+            "name": "NubladoPythonLoop",
             "success_count": 1,
             "timings": ANY,
         },
@@ -89,7 +89,7 @@ async def test_reuse_lab(
             "user_spec": {"username_prefix": "testuser"},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {
                     "spawn_settle_time": 0,
                     "delete_lab": False,
@@ -123,7 +123,7 @@ async def test_server_shutdown(
             "user_spec": {"username_prefix": "testuser"},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {"spawn_settle_time": 0, "max_executions": 3},
             },
         },
@@ -151,7 +151,7 @@ async def test_delayed_delete(
             "user_spec": {"username_prefix": "testuser"},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {"spawn_settle_time": 0, "delete_lab": False},
             },
         },
@@ -184,7 +184,7 @@ async def test_hub_failed(
             "user_spec": {"username_prefix": "testuser"},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {"spawn_settle_time": 0, "delete_lab": False},
             },
         },
@@ -269,7 +269,7 @@ async def test_redirect_loop(
             "user_spec": {"username_prefix": "testuser"},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {"spawn_settle_time": 0, "delete_lab": False},
             },
         },
@@ -360,7 +360,7 @@ async def test_spawn_timeout(
             "user_spec": {"username_prefix": "testuser"},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {"spawn_settle_time": 0, "spawn_timeout": 1},
             },
         },
@@ -434,7 +434,7 @@ async def test_spawn_failed(
             "user_spec": {"username_prefix": "testuser"},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {"spawn_settle_time": 0, "spawn_timeout": 1},
             },
         },
@@ -522,7 +522,7 @@ async def test_delete_timeout(
             "user_spec": {"username_prefix": "testuser"},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {
                     "spawn_settle_time": 0,
                     "delete_timeout": 1,
@@ -602,7 +602,7 @@ async def test_code_exception(
             "user_spec": {"username_prefix": "testuser"},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {
                     "code": 'raise Exception("some error")',
                     "spawn_settle_time": 0,
@@ -718,7 +718,7 @@ async def test_long_error(
             "user_spec": {"username_prefix": "testuser"},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {
                     "code": "long_error_for_test()",
                     "image": {
@@ -850,7 +850,7 @@ async def test_lab_controller(
             "users": [{"username": "testuser"}],
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {
                     "image": {
                         "image_class": "by-reference",
@@ -883,7 +883,7 @@ async def test_lab_controller(
             "users": [{"username": "testuser"}],
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {
                     "image": {
                         "image_class": "latest-daily",
@@ -913,7 +913,7 @@ async def test_lab_controller(
             "users": [{"username": "testuser"}],
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {
                     "image": {
                         "image_class": "by-tag",
@@ -949,7 +949,7 @@ async def test_ansi_error(
             "user_spec": {"username_prefix": "testuser"},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {
                     "code": (
                         'raise ValueError("\\033[38;5;28;01mFoo\\033[39;00m")'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,7 +86,7 @@ def cachemachine(respx_mock: respx.Router) -> MockCachemachine:
 
 @pytest.fixture
 def jupyter(respx_mock: respx.Router) -> Iterator[MockJupyter]:
-    """Mock out JupyterHub/Lab."""
+    """Mock out JupyterHub and Jupyter labs."""
     jupyter_mock = mock_jupyter(respx_mock)
 
     # respx has no mechanism to mock aconnect_ws, so we have to do it
@@ -100,7 +100,7 @@ def jupyter(respx_mock: respx.Router) -> Iterator[MockJupyter]:
     ) -> AsyncIterator[MockJupyterWebSocket]:
         yield mock_jupyter_websocket(url, extra_headers, jupyter_mock)
 
-    with patch("mobu.storage.jupyter.websocket_connect") as mock:
+    with patch("mobu.storage.nublado.websocket_connect") as mock:
         mock.side_effect = mock_connect
         yield jupyter_mock
 

--- a/tests/handlers/solitary_test.py
+++ b/tests/handlers/solitary_test.py
@@ -43,7 +43,7 @@ async def test_error(
             "user": {"username": "solitary"},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "JupyterPythonLoop",
+                "type": "NubladoPythonLoop",
                 "options": {
                     "code": 'raise Exception("some error")',
                     "spawn_settle_time": 0,


### PR DESCRIPTION
mobu will not work with an arbitrary JupyterHub; it requires Nublado specifically. Rename JupyterPythonLoop to NubaldoPythonLoop and JupyterClient to NubladoClient to reflect this, although keep the Jupyter naming for things that are more generic to any JupyterHub.