### PR TITLE
DM-42225: Convert intervals to timedeltas

### DIFF
--- a/changelog.d/20231215_150943_rra_DM_42225.md
+++ b/changelog.d/20231215_150943_rra_DM_42225.md
@@ -1,0 +1,3 @@
+### New features
+
+- Convert all configuration options that took intervals in seconds to `timedelta`. Bare numbers will still be interpreted as a number of seconds, but any format Pydantic recognizes as a `timedelta` may now be used.

--- a/src/mobu/asyncio.py
+++ b/src/mobu/asyncio.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 from asyncio import Task
 from collections.abc import Awaitable, Callable, Coroutine
+from datetime import timedelta
 from typing import TypeVar
 
 T = TypeVar("T")
@@ -14,13 +15,26 @@ __all__ = ["schedule_periodic", "wait_first"]
 
 
 def schedule_periodic(
-    func: Callable[[], Awaitable[None]], interval_seconds: int
+    func: Callable[[], Awaitable[None]], interval: timedelta
 ) -> Task:
-    """Schedule a function to run periodically."""
+    """Schedule a function to run periodically.
+
+    Parmaeters
+    ----------
+    func
+        Async function to call periodically.
+    interval
+        How long to pause between executions.
+
+    Returns
+    -------
+    Task
+        Running task that will call the function periodically.
+    """
 
     async def loop() -> None:
         while True:
-            await asyncio.sleep(interval_seconds)
+            await asyncio.sleep(interval.total_seconds())
             await func()
 
     return asyncio.ensure_future(loop())

--- a/src/mobu/main.py
+++ b/src/mobu/main.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from datetime import timedelta
 from importlib.metadata import metadata, version
 
 import structlog
@@ -39,7 +40,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         raise RuntimeError("MOBU_GAFAELFAWR_TOKEN was not set")
     await context_dependency.initialize()
     await context_dependency.process_context.manager.autostart()
-    app.state.periodic_status = schedule_periodic(post_status, 60 * 60 * 24)
+    status_interval = timedelta(days=1)
+    app.state.periodic_status = schedule_periodic(post_status, status_interval)
 
     yield
 

--- a/src/mobu/models/business/base.py
+++ b/src/mobu/models/business/base.py
@@ -1,6 +1,9 @@
 """Base models for monkey business."""
 
-from pydantic import BaseModel, ConfigDict, Field
+from datetime import timedelta
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, PlainSerializer
 
 from ..timings import StopwatchData
 
@@ -8,24 +11,32 @@ __all__ = [
     "BusinessConfig",
     "BusinessOptions",
     "BusinessData",
+    "SerializableTimedelta",
+]
+
+SerializableTimedelta = Annotated[
+    timedelta,
+    PlainSerializer(
+        lambda v: round(v.total_seconds()), return_type=int, when_used="json"
+    ),
 ]
 
 
 class BusinessOptions(BaseModel):
     """Options for monkey business."""
 
-    error_idle_time: int = Field(
-        60,
+    error_idle_time: SerializableTimedelta = Field(
+        timedelta(minutes=1),
         title="How long to wait after an error before restarting",
         examples=[600],
     )
 
-    idle_time: int = Field(
-        60,
+    idle_time: SerializableTimedelta = Field(
+        timedelta(minutes=1),
         title="How long to wait between business executions",
         description=(
             "AFter each loop executing monkey business, the monkey will"
-            " pause for this long in seconds"
+            " pause for this long"
         ),
         examples=[60],
     )

--- a/src/mobu/models/business/nublado.py
+++ b/src/mobu/models/business/nublado.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
+from datetime import timedelta
 from enum import Enum
 from typing import Literal
 
 from pydantic import BaseModel, Field
 
-from .base import BusinessData, BusinessOptions
+from .base import BusinessData, BusinessOptions, SerializableTimedelta
 
 __all__ = [
     "NubladoBusinessData",
@@ -152,13 +153,13 @@ class NubladoBusinessOptions(BusinessOptions):
         examples=[True],
     )
 
-    delete_timeout: int = Field(
-        60, title="Timeout for deleting a lab in seconds", examples=[60]
+    delete_timeout: SerializableTimedelta = Field(
+        timedelta(minutes=1), title="Timeout for deleting a lab", examples=[60]
     )
 
-    execution_idle_time: int = Field(
-        1,
-        title="How long to wait between cell executions in seconds",
+    execution_idle_time: SerializableTimedelta = Field(
+        timedelta(seconds=1),
+        title="How long to wait between cell executions",
         description="Used by NubladoPythonLoop and NotebookRunner",
         examples=[1],
     )
@@ -178,12 +179,12 @@ class NubladoBusinessOptions(BusinessOptions):
         default_factory=NubladoImageByClass, title="Nublado lab image to use"
     )
 
-    jitter: int = Field(
-        0,
+    jitter: SerializableTimedelta = Field(
+        timedelta(seconds=0),
         title="Maximum random time to pause",
         description=(
             "If set to a non-zero value, pause for a random interval between"
-            " 0 and that many seconds before logging in to JupyterHub, and"
+            " 0 and that interval before logging in to JupyterHub, and"
             " between each iteration of the core execution loop. Use this when"
             " running lots of monkeys for load testing to spread their"
             " execution sequence out more realistically and avoid a thundering"
@@ -192,8 +193,8 @@ class NubladoBusinessOptions(BusinessOptions):
         examples=[60],
     )
 
-    jupyter_timeout: int = Field(
-        60,
+    jupyter_timeout: SerializableTimedelta = Field(
+        timedelta(minutes=1),
         title="HTTP client timeout for Jupyter requests",
         description=(
             "Used as the connect, read, and write timeout for talking to"
@@ -211,9 +212,9 @@ class NubladoBusinessOptions(BusinessOptions):
         ),
     )
 
-    spawn_settle_time: int = Field(
-        10,
-        title="How long to wait before polling spawn progress in seconds",
+    spawn_settle_time: SerializableTimedelta = Field(
+        timedelta(seconds=10),
+        title="How long to wait before polling spawn progress",
         description=(
             "Wait this long after triggering a lab spawn before starting to"
             " poll its progress. KubeSpawner 1.1.0 has a bug where progress"
@@ -223,8 +224,10 @@ class NubladoBusinessOptions(BusinessOptions):
         examples=[10],
     )
 
-    spawn_timeout: int = Field(
-        610, title="Timeout for spawning a lab in seconds", examples=[610]
+    spawn_timeout: SerializableTimedelta = Field(
+        timedelta(seconds=610),
+        title="Timeout for spawning a lab",
+        examples=[610],
     )
 
     url_prefix: str = Field("/nb/", title="URL prefix for JupyterHub")

--- a/src/mobu/models/timings.py
+++ b/src/mobu/models/timings.py
@@ -1,8 +1,9 @@
 """Models for timing data."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
+from typing import Annotated
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PlainSerializer
 
 
 class StopwatchData(BaseModel):
@@ -29,9 +30,16 @@ class StopwatchData(BaseModel):
         examples=["2021-07-21T19:43:40.514623+00:00"],
     )
 
-    elapsed: float | None = Field(
+    elapsed: Annotated[
+        timedelta | None,
+        PlainSerializer(
+            lambda v: v.total_seconds() if v is not None else None,
+            return_type=float,
+            when_used="json",
+        ),
+    ] = Field(
         None,
-        title="Duration of event in seconds",
+        title="Duration of event",
         description="Will be null if the event is ongoing",
         examples=[0.068551],
     )

--- a/src/mobu/services/timings.py
+++ b/src/mobu/services/timings.py
@@ -110,9 +110,7 @@ class Stopwatch:
 
     def dump(self) -> StopwatchData:
         """Convert to a Pydantic model."""
-        elapsed = None
-        if self.stop_time:
-            elapsed = (self.stop_time - self.start_time).total_seconds()
+        elapsed = self.stop_time - self.start_time if self.stop_time else None
         return StopwatchData(
             event=self.event,
             annotations=self.annotations,

--- a/src/mobu/storage/nublado.py
+++ b/src/mobu/storage/nublado.py
@@ -11,6 +11,7 @@ import json
 import string
 from collections.abc import AsyncIterator, Callable, Coroutine
 from dataclasses import dataclass
+from datetime import timedelta
 from functools import wraps
 from random import SystemRandom
 from types import TracebackType
@@ -543,7 +544,7 @@ class NubladoClient:
         user: AuthenticatedUser,
         base_url: str,
         logger: BoundLogger,
-        timeout: int = 30,
+        timeout: timedelta = timedelta(seconds=30),
     ) -> None:
         self.user = user
         self._base_url = base_url
@@ -569,7 +570,7 @@ class NubladoClient:
             headers=headers,
             cookies=cookies,
             follow_redirects=True,
-            timeout=timeout,
+            timeout=timeout.total_seconds(),
         )
 
     async def close(self) -> None:

--- a/tests/timings_test.py
+++ b/tests/timings_test.py
@@ -48,7 +48,7 @@ def test_timings() -> None:
             annotations={},
             start=first_sw.start_time,
             stop=first_sw.stop_time,
-            elapsed=first_sw.elapsed.total_seconds(),
+            elapsed=first_sw.elapsed,
             failed=False,
         ),
         StopwatchData(
@@ -56,7 +56,7 @@ def test_timings() -> None:
             annotations={"foo": "bar"},
             start=second_sw.start_time,
             stop=second_sw.stop_time,
-            elapsed=second_sw.elapsed.total_seconds(),
+            elapsed=second_sw.elapsed,
             failed=True,
         ),
     ]


### PR DESCRIPTION
Use timedelta uniformly internally as the data time for time intervals instead of using an integer number of seconds. Define a serialization format so that the output from the API will stay the same.