### PR TITLE
DM-42225: Prepare 7.0.0 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
       - id: check-toml
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.7
+    rev: v0.1.8
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,27 @@
 # Change log
 
-All notable changes to mobu will be documented in this file.
+mobu is versioned with [semver](https://semver.org/). Dependencies are updated to the latest available version during each release. Those changes are not noted here explicitly.
 
-Versioning follows [semver](https://semver.org/).
-
-Dependencies are updated to the latest available version during each release. Those changes are not noted here explicitly.
-
-This project uses [scriv](https://scriv.readthedocs.io/) to maintain the change log.
-Changes for the upcoming release can be found in [changelog.d](https://github.com/lsst-sqre/mobu/tree/main/changelog.d/).
+Find changes for the upcoming release in the project's [changelog.d](https://github.com/lsst-sqre/mobu/tree/main/changelog.d/).
 
 <!-- scriv-insert-here -->
+
+<a id='changelog-7.0.0'></a>
+## 7.0.0 (2023-12-15)
+
+### Backwards-incompatible changes
+
+- Drop support for cachemachine and Nublado v2. The `cachemachine_image_policy` and `use_cachemachine` configuration options are no longer supported and should be deleted.
+- Rename the existing `TAPQueryRunner` business to `TAPQuerySetRunner` to more accurately capture what it does. Add a new `TAPQueryRunner` business that runs queries chosen randomly from a list. Based on work by @stvoutsin.
+- Rename `JupyterPythonLoop` to `NubladoPythonLoop` to make it explicit that it requires Nublado and will not work with an arbitrary JupyterHub.
+
+### New features
+
+- Convert all configuration options that took intervals in seconds to `timedelta`. Bare numbers will still be interpreted as a number of seconds, but any format Pydantic recognizes as a `timedelta` may now be used.
+
+### Other changes
+
+- All environment variables used to configure mobu now start with `MOBU_`, and several have changed their names. The new settings are `MOBU_ALERT_HOOK`, `MOBU_AUTOSTART_PATH`, `MOBU_ENVIRONMENT_URL`, `MOBU_GAFAELFAWR_TOKEN`, `MOBU_NAME`, `MOBU_PATH_PREFIX`, `MOBU_LOGGING_PROFILE`, and `MOBU_LOG_LEVEL`. This is handled by the Phalanx application, so no configuration changes should be required.
 
 <a id='changelog-6.1.1'></a>
 ## 6.1.1 (2023-07-06)

--- a/changelog.d/20231214_124422_rra_DM_42182.md
+++ b/changelog.d/20231214_124422_rra_DM_42182.md
@@ -1,3 +1,0 @@
-### Backwards-incompatible changes
-
-- Rename the existing `TAPQueryRunner` business to `TAPQuerySetRunner` to more accurately capture what it does. Add a new `TAPQueryRunner` business that runs queries chosen randomly from a list. Based on work by @stvoutsin.

--- a/changelog.d/20231214_165219_rra_DM_42182.md
+++ b/changelog.d/20231214_165219_rra_DM_42182.md
@@ -1,3 +1,0 @@
-### Other changes
-
-- All environment variables used to configure mobu now start with `MOBU_`, and several have changed their names. The new settings are `MOBU_ALERT_HOOK`, `MOBU_AUTOSTART_PATH`, `MOBU_ENVIRONMENT_URL`, `MOBU_GAFAELFAWR_TOKEN`, `MOBU_NAME`, `MOBU_PATH_PREFIX`, `MOBU_LOGGING_PROFILE`, and `MOBU_LOG_LEVEL`. This is handled by the Phalanx application, so no configuration changes should be required.

--- a/changelog.d/20231215_141606_rra.md
+++ b/changelog.d/20231215_141606_rra.md
@@ -1,3 +1,0 @@
-### Backwards-incompatible changes
-
-- Rename `JupyterPythonLoop` to `NubladoPythonLoop` to make it explicit that it requires Nublado and will not work with an arbitrary JupyterHub.

--- a/changelog.d/20231215_143527_rra_DM_42225.md
+++ b/changelog.d/20231215_143527_rra_DM_42225.md
@@ -1,3 +1,0 @@
-### Backwards-incompatible changes
-
-- Drop support for cachemachine and Nublado v2. The `cachemachine_image_policy` and `use_cachemachine` configuration options are no longer supported and should be deleted.

--- a/changelog.d/20231215_150943_rra_DM_42225.md
+++ b/changelog.d/20231215_150943_rra_DM_42225.md
@@ -1,3 +1,0 @@
-### New features
-
-- Convert all configuration options that took intervals in seconds to `timedelta`. Bare numbers will still be interpreted as a number of seconds, but any format Pydantic recognizes as a `timedelta` may now be used.

--- a/scripts/install-base-packages.sh
+++ b/scripts/install-base-packages.sh
@@ -24,6 +24,10 @@ apt-get update
 # Install security updates.
 apt-get -y upgrade
 
+# Install dependencies required at runtime. git is used to check out notebook
+# repositories.
+apt-get -y install --no-install-recommends git
+
 # Delete cached files we don't need anymore.
 apt-get clean
 rm -rf /var/lib/apt/lists/*

--- a/scripts/install-dependency-packages.sh
+++ b/scripts/install-dependency-packages.sh
@@ -25,7 +25,6 @@ apt-get update
 # Install various dependencies that may be required to install mobu:
 #
 # build-essential: sometimes needed to build Python modules
-# git: required by setuptools_scm
 # libffi-dev: sometimes needed to build cffi, a cryptography dependency
 apt-get -y install --no-install-recommends build-essential git libffi-dev
 


### PR DESCRIPTION
Restore git to the base image because it's required at runtime.