### PR TITLE
Fix syntax in periodic CI

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Run neophile
         uses: lsst-sqre/run-neophile@v1
         with:
-          python-version: $(( matrix.python }}
+          python-version: ${{ matrix.python }}
           mode: update
 
       - name: Run tox


### PR DESCRIPTION
The periodic CI GitHub Actions configuration was using incorrect syntax for calling into run-neophile. Fix that.