### PR TITLE
Install pre-commit before calling autoupdate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: update-deps
 update-deps:
+	pip install --upgrade pre-commit
 	pre-commit autoupdate
 	pip install --upgrade pip-tools pip setuptools
 	pip-compile --upgrade --resolver=backtracking --build-isolation	\


### PR DESCRIPTION
The periodic CI job runs make update-deps, so install pre-commit first before running pre-commit autoupdate, rather than assuming make init has already been run.