### PR TITLE
DM-43423: Fix XSRF cookie and header handling for JupyterLab

### DIFF
--- a/changelog.d/20240321_110225_rra_DM_43423.md
+++ b/changelog.d/20240321_110225_rra_DM_43423.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Properly handle the XSRF tokens for JupyterHub and the Jupyter lab by storing separate tokens for the hub and lab after initial login and sending the appropriate XSRF token in the `X-XSRFToken` header to the relevant APIs. This fixes a redirect loop at the Jupyter lab when running 4.1.0 or later.

--- a/src/mobu/exceptions.py
+++ b/src/mobu/exceptions.py
@@ -31,6 +31,7 @@ __all__ = [
     "FlockNotFoundError",
     "GafaelfawrParseError",
     "GafaelfawrWebError",
+    "JupyterProtocolError",
     "JupyterTimeoutError",
     "JupyterWebError",
     "MobuSlackException",
@@ -340,6 +341,10 @@ class CodeExecutionError(MobuSlackException):
             blocks=self.common_blocks(),
             attachments=attachments,
         )
+
+
+class JupyterProtocolError(MobuSlackException):
+    """Some error occurred when talking to JupyterHub or JupyterLab."""
 
 
 class JupyterSpawnError(MobuSlackException):


### PR DESCRIPTION
Previously, mobu created a fake XSRF cookie and header and sent them blindly to JupyterLab. JupyterLab now expects the cookie to be in a specific format and is rejecting our fake one.

Instead, properly implement the same protocol as the JavaScript client: retrieve the _xsrf cookie from the response from the lab and lift it into the X-XSRFToken header. Raise an exception if the lab does not send an _xsrf cookie so that we'll catch further changes more quickly.

This is complicated by the fact that the hub and lab use separate XSRF tokens restricted to different paths, so we need to track both tokens and send the appropriate header based on which API we're talking to.