### PR TITLE
DM-43573: Handle cookies from JupyterLab redirects

### DIFF
--- a/changelog.d/20240328_111901_rra_DM_43573.md
+++ b/changelog.d/20240328_111901_rra_DM_43573.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Correctly extract cookies from the middle of the redirect chain caused by initial authentication to a Nublado lab. This fixes failures seen with labs containing jupyterhub 4.1.3.


### PR DESCRIPTION
httpx does not preserve cookies set by intermediate steps of a redirect chain when following redirects automatically, and the lab sets the XSRF cookie from the oath_callback route and then redirects to the actual lab URL. Disable automatic redirect handling for the lab login and attempt to extract an XSRF cookie at each step.

Also send Sec-Fetch-Mode: navigate to suppress a harmless but annoying logging message in JupyterHub.