### PR TITLE
DM-45709: Don't run notebooks in environments that don't have the necessary services

### DIFF
--- a/changelog.d/20240719_150741_danfuchs.md
+++ b/changelog.d/20240719_150741_danfuchs.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### New features
+
+- `NotebookRunner` business will skip notebooks in environments that do not have the services required for them to run. Required services ban be declared by adding [metadata](https://ipython.readthedocs.io/en/3.x/notebook/nbformat.html#metadata) to a notebook.

--- a/src/mobu/config.py
+++ b/src/mobu/config.py
@@ -87,6 +87,19 @@ class Configuration(BaseSettings):
         examples=["gt-vilSCi1ifK_MyuaQgMD2dQ.d6SIJhowv5Hs3GvujOyUig"],
     )
 
+    available_services: set[str] = Field(
+        set(),
+        title="Available platform services",
+        description=(
+            "Names of services available in the current environment. For now,"
+            " this list is manually maintained in the mobu config in Phalanx."
+            " When we have a service discovery mechanism in place, it should"
+            " be used here."
+        ),
+        validation_alias="MOBU_AVAILABLE_SERVICES",
+        examples=[{"tap", "ssotap", "butler"}],
+    )
+
     name: str = Field(
         "mobu",
         title="Name of application",

--- a/src/mobu/models/business/notebookrunner.py
+++ b/src/mobu/models/business/notebookrunner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from ...constants import NOTEBOOK_REPO_BRANCH, NOTEBOOK_REPO_URL
 from .base import BusinessConfig
@@ -99,4 +99,19 @@ class NotebookRunnerData(NubladoBusinessData):
         title="Currently running code",
         description="Will not be present if no code is being executed",
         examples=['import json\nprint(json.dumps({"foo": "bar"})\n'],
+    )
+
+
+class NotebookMetadata(BaseModel):
+    """Notebook metadata that we care about."""
+
+    required_services: set[str] = Field(
+        set(),
+        title="Required services",
+        description=(
+            "The names of services that the platform is required to provide in"
+            " order for the notebook to run correctly. Not all environments"
+            " provide all services."
+        ),
+        examples=[{"tap", "ssotap", "butler"}],
     )

--- a/src/mobu/services/business/notebookrunner.py
+++ b/src/mobu/services/business/notebookrunner.py
@@ -18,8 +18,10 @@ from typing import Any
 from httpx import AsyncClient
 from structlog.stdlib import BoundLogger
 
+from ...config import config
 from ...exceptions import NotebookRepositoryError
 from ...models.business.notebookrunner import (
+    NotebookMetadata,
     NotebookRunnerData,
     NotebookRunnerOptions,
 )
@@ -110,6 +112,25 @@ class NotebookRunner(NubladoBusiness):
         # A notebook is excluded if any of its parent directories are excluded
         return bool(set(notebook.parents) & self._exclude_paths)
 
+    def missing_services(self, notebook: Path) -> bool:
+        """Return True if a notebook declares required services and they are
+        available.
+        """
+        metadata = self.read_notebook_metadata(notebook)
+        missing_services = (
+            metadata.required_services - config.available_services
+        )
+        if missing_services:
+            msg = "Environment does not provide required services for notebook"
+            self.logger.info(
+                msg,
+                notebook=notebook,
+                required_services=metadata.required_services,
+                missing_services=missing_services,
+            )
+            return True
+        return False
+
     def find_notebooks(self) -> list[Path]:
         with self.timings.start("find_notebooks"):
             if self._repo_dir is None:
@@ -119,8 +140,10 @@ class NotebookRunner(NubladoBusiness):
             notebooks = [
                 n
                 for n in self._repo_dir.glob("**/*.ipynb")
-                if not self.is_excluded(n)
+                if not (self.is_excluded(n) or self.missing_services(n))
             ]
+
+            # Filter for explicit notebooks
             if self.options.notebooks_to_run:
                 requested = [
                     self._repo_dir / notebook
@@ -138,6 +161,7 @@ class NotebookRunner(NubladoBusiness):
                     "Running with explicit list of notebooks",
                     notebooks=notebooks,
                 )
+
             if not notebooks:
                 msg = "No notebooks found in {self._repo_dir}"
                 raise NotebookRepositoryError(msg, self.user.username)
@@ -148,6 +172,20 @@ class NotebookRunner(NubladoBusiness):
         if not self._notebook_paths:
             self._notebook_paths = self.find_notebooks()
         return self._notebook_paths.pop()
+
+    def read_notebook_metadata(self, notebook: Path) -> NotebookMetadata:
+        """Extract mobu-specific metadata from a notebook."""
+        with self.timings.start(
+            "read_notebook_metadata", {"notebook": notebook.name}
+        ):
+            try:
+                notebook_text = notebook.read_text()
+                notebook_json = json.loads(notebook_text)
+                metadata = notebook_json["metadata"].get("mobu", {})
+                return NotebookMetadata.model_validate(metadata)
+            except Exception as e:
+                msg = f"Invalid notebook metadata {notebook.name}: {e!s}"
+                raise NotebookRepositoryError(msg, self.user.username) from e
 
     def read_notebook(self, notebook: Path) -> list[dict[str, Any]]:
         with self.timings.start("read_notebook", {"notebook": notebook.name}):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,9 +56,11 @@ def _configure() -> Iterator[None]:
     """
     config.environment_url = HttpUrl("https://test.example.com")
     config.gafaelfawr_token = make_gafaelfawr_token()
+    config.available_services = {"some_service", "some_other_service"}
     yield
     config.environment_url = None
     config.gafaelfawr_token = None
+    config.available_services = set()
 
 
 @pytest.fixture

--- a/tests/data/notebooks_services/test-notebook-has-services.ipynb
+++ b/tests/data/notebooks_services/test-notebook-has-services.ipynb
@@ -1,0 +1,64 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5cb3e0b7",
+   "metadata": {},
+   "source": [
+    "This is a test notebook to check the NotebookRunner business. It contains some Markdown cells and some code cells. Only the code cells should run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f84f0959",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Required services are available\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53a941a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Final test\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "823560c6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "mobu": {
+   "required_services": ["some_service"]
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/data/notebooks_services/test-notebook-missing-service.ipynb
+++ b/tests/data/notebooks_services/test-notebook-missing-service.ipynb
@@ -1,0 +1,64 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5cb3e0b7",
+   "metadata": {},
+   "source": [
+    "This is a test notebook to check the NotebookRunner business. It contains some Markdown cells and some code cells. Only the code cells should run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f84f0959",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Required services are NOT available\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53a941a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Final test\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "823560c6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "mobu": {
+   "required_services": ["nope"]
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
* Parse a 'mobu' section out of notebook metadata
* Add a list of available services to app config (to be replaced by some kind of service discovery at some point)
* Don't run the notebook if it declares required services in the metadata and the services aren't available in the environment.

Putting the required services in the notebook metadata can be done in JupyterLab, though is not the nicest UX for this. We now have an in-repo config file (mobu.yaml), maybe it would be better to keep a manifest in there? I like having it closer to the notebook though. I'm open to other suggestions.