### PR TITLE
DM-45079: Execute only non-filtered notebooks  when requesting explicit notebooks

### DIFF
--- a/src/mobu/models/business/notebookrunner.py
+++ b/src/mobu/models/business/notebookrunner.py
@@ -13,6 +13,7 @@ from .nublado import NubladoBusinessData, NubladoBusinessOptions
 
 __all__ = [
     "ListNotebookRunnerOptions",
+    "NotebookFilterResults",
     "NotebookRunnerConfig",
     "NotebookRunnerData",
     "NotebookRunnerOptions",
@@ -120,4 +121,49 @@ class NotebookMetadata(BaseModel):
             " provide all services."
         ),
         examples=[{"tap", "ssotap", "butler"}],
+    )
+
+
+class NotebookFilterResults(BaseModel):
+    """Valid notebooks and categories for invalid notebooks."""
+
+    all: set[Path] = Field(
+        default=set(),
+        title="All notebooks",
+        description="All notebooks in the repository",
+    )
+
+    runnable: set[Path] = Field(
+        default=set(),
+        title="Runnable notebooks",
+        description=(
+            "These are the notebooks to run after all filtering has been done"
+        ),
+    )
+
+    excluded_by_dir: set[Path] = Field(
+        default=set(),
+        title="Excluded by directory",
+        description=(
+            "These notebooks won't be run because they are in a directory that"
+            "is excliticly excluded"
+        ),
+    )
+
+    excluded_by_service: set[Path] = Field(
+        default=set(),
+        title="Excluded by service availability",
+        description=(
+            "These notebooks won't be run because the depend on services which"
+            " are not available in this environment"
+        ),
+    )
+
+    excluded_by_requested: set[Path] = Field(
+        default=set(),
+        title="Excluded by explicit list",
+        description=(
+            "These notebooks won't be run because a list of explicitly"
+            " requested notebooks was provided, and they weren't in it."
+        ),
     )

--- a/src/mobu/models/business/notebookrunner.py
+++ b/src/mobu/models/business/notebookrunner.py
@@ -12,14 +12,43 @@ from .base import BusinessConfig
 from .nublado import NubladoBusinessData, NubladoBusinessOptions
 
 __all__ = [
+    "ListNotebookRunnerOptions",
     "NotebookRunnerConfig",
     "NotebookRunnerData",
     "NotebookRunnerOptions",
 ]
 
 
-class NotebookRunnerOptions(NubladoBusinessOptions):
-    """Options for NotebookRunner monkey business."""
+class BaseNotebookRunnerOptions(NubladoBusinessOptions):
+    """Options for all types NotebookRunner monkey business."""
+
+    repo_ref: str = Field(
+        NOTEBOOK_REPO_BRANCH,
+        title="Git ref of notebook repository to execute",
+        description="Only used by the NotebookRunner",
+        examples=["main", "03cd564dd2025bf17054d9ebfeeb5c5a266e3484"],
+    )
+
+    repo_url: str = Field(
+        NOTEBOOK_REPO_URL,
+        title="Git URL of notebook repository to execute",
+        description="Only used by the NotebookRunner",
+    )
+
+    exclude_dirs: set[Path] = Field(
+        set(),
+        title="Any notebooks in these directories will not be run",
+        description=(
+            " These directories are relative to the repo root. Any notebooks"
+            " in child directories of these directories will also be excluded."
+            " Only used by the NotebookRunner."
+        ),
+        examples=["some-dir", "some-dir/some-other-dir"],
+    )
+
+
+class NotebookRunnerOptions(BaseNotebookRunnerOptions):
+    """Options to specify a fixed number of notebooks to run per session."""
 
     max_executions: int = Field(
         25,
@@ -37,26 +66,14 @@ class NotebookRunnerOptions(NubladoBusinessOptions):
         ge=1,
     )
 
-    repo_ref: str = Field(
-        NOTEBOOK_REPO_BRANCH,
-        title="Git ref of notebook repository to execute",
-        description="Only used by the NotebookRunner",
-        examples=["main", "03cd564dd2025bf17054d9ebfeeb5c5a266e3484"],
-    )
 
-    repo_url: str = Field(
-        NOTEBOOK_REPO_URL,
-        title="Git URL of notebook repository to execute",
-        description="Only used by the NotebookRunner",
-    )
+class ListNotebookRunnerOptions(BaseNotebookRunnerOptions):
+    """Options to specify a list of notebooks to run per session."""
 
     notebooks_to_run: list[Path] = Field(
         [],
         title="Specific notebooks to run",
-        description=(
-            "If this is set, then only these specific notebooks will be"
-            " executed."
-        ),
+        description=("Only these specific notebooks will be executed."),
     )
 
 
@@ -67,7 +84,7 @@ class NotebookRunnerConfig(BusinessConfig):
         ..., title="Type of business to run"
     )
 
-    options: NotebookRunnerOptions = Field(
+    options: NotebookRunnerOptions | ListNotebookRunnerOptions = Field(
         default_factory=NotebookRunnerOptions,
         title="Options for the monkey business",
     )

--- a/src/mobu/services/business/notebookrunner.py
+++ b/src/mobu/services/business/notebookrunner.py
@@ -196,7 +196,7 @@ class NotebookRunner(NubladoBusiness):
                 if not_found:
                     msg = (
                         "Requested notebooks do not exist in"
-                        " {self._repo_dir}: {not_found}"
+                        f" {self._repo_dir}: {not_found}"
                     )
                     raise NotebookRepositoryError(msg, self.user.username)
                 filter_results.excluded_by_requested = (

--- a/src/mobu/services/github_ci/ci_notebook_job.py
+++ b/src/mobu/services/github_ci/ci_notebook_job.py
@@ -6,8 +6,8 @@ from httpx import AsyncClient
 from structlog.stdlib import BoundLogger
 
 from mobu.models.business.notebookrunner import (
+    ListNotebookRunnerOptions,
     NotebookRunnerConfig,
-    NotebookRunnerOptions,
 )
 from mobu.models.solitary import SolitaryConfig
 from mobu.models.user import User
@@ -80,8 +80,7 @@ class CiNotebookJob:
             scopes=[str(scope) for scope in scopes],
             business=NotebookRunnerConfig(
                 type="NotebookRunner",
-                options=NotebookRunnerOptions(
-                    max_executions=len(self._notebooks),
+                options=ListNotebookRunnerOptions(
                     repo_ref=self._github.ref,
                     repo_url=f"https://github.com/{self._github.repo_owner}/{self._github.repo_name}.git",
                     notebooks_to_run=self._notebooks,

--- a/src/mobu/services/github_ci/ci_notebook_job.py
+++ b/src/mobu/services/github_ci/ci_notebook_job.py
@@ -73,6 +73,11 @@ class CiNotebookJob:
         # Run notebooks using a Solitary runner
         summary = "Running these notebooks via Mobu:\n" + "\n".join(
             [f"* {notebook}" for notebook in self._notebooks]
+            + [
+                "Note that not all of these may run. Some may be exluded based"
+                " on config in the repo:"
+                " https://mobu.lsst.io/user_guide/in_repo_config.html"
+            ]
         )
         await self.check_run.start(summary=summary)
         solitary_config = SolitaryConfig(

--- a/tests/business/notebookrunner_test.py
+++ b/tests/business/notebookrunner_test.py
@@ -241,9 +241,100 @@ async def test_run_required_services(
                     "options": {
                         "spawn_settle_time": 0,
                         "execution_idle_time": 0,
-                        "max_executions": 1,
+                        "max_executions": 2,
                         "repo_url": str(repo_path),
                         "repo_ref": "main",
+                        "working_directory": str(repo_path),
+                    },
+                },
+            },
+        )
+        assert r.status_code == 201
+
+        # Wait until we've finished one loop and check the results.
+        data = await wait_for_business(client, "bot-mobu-testuser1")
+        assert data == {
+            "name": "bot-mobu-testuser1",
+            "business": {
+                "failure_count": 0,
+                "name": "NotebookRunner",
+                "notebook": ANY,
+                "refreshing": False,
+                "success_count": 1,
+                "timings": ANY,
+            },
+            "state": "RUNNING",
+            "user": {
+                "scopes": ["exec:notebook"],
+                "token": ANY,
+                "username": "bot-mobu-testuser1",
+            },
+        }
+    finally:
+        os.chdir(cwd)
+
+    # Get the log and check the cell output.
+    r = await client.get("/mobu/flocks/test/monkeys/bot-mobu-testuser1/log")
+    assert r.status_code == 200
+
+    # Notebooks with all services available
+    assert "Required services are available" in r.text
+    assert "Required services are available - some-dir" in r.text
+    assert "Final test" in r.text
+
+    # Notebook with missing services
+    assert "Required services are NOT available" not in r.text
+
+    # Make sure mobu ran all of the notebooks it thinks it should have
+    assert "Done with this cycle of notebooks" in r.text
+
+
+@pytest.mark.asyncio
+async def test_run_all_notebooks(
+    client: AsyncClient, respx_mock: respx.Router, tmp_path: Path
+) -> None:
+    mock_gafaelfawr(respx_mock)
+    cwd = Path.cwd()
+
+    # Set up a notebook repository.
+    source_path = TEST_DATA_DIR / "notebooks_services"
+    repo_path = tmp_path / "notebooks"
+
+    shutil.copytree(str(source_path), str(repo_path))
+
+    # Exclude some notebooks
+    (repo_path / "mobu.yaml").write_text('exclude_dirs: ["some-dir"]')
+
+    # Set up git repo
+    await setup_git_repo(repo_path)
+
+    # Start a monkey. We have to do this in a try/finally block since the
+    # runner will change working directories, which because working
+    # directories are process-global may mess up future tests.
+    try:
+        # Note `max_executions` is not declared here, `notebooks_to_run` is
+        # declared instead.
+        r = await client.put(
+            "/mobu/flocks",
+            json={
+                "name": "test",
+                "count": 1,
+                "user_spec": {"username_prefix": "bot-mobu-testuser"},
+                "scopes": ["exec:notebook"],
+                "business": {
+                    "type": "NotebookRunner",
+                    "options": {
+                        "spawn_settle_time": 0,
+                        "execution_idle_time": 0,
+                        "repo_url": str(repo_path),
+                        "repo_ref": "main",
+                        "notebooks_to_run": [
+                            "test-notebook-has-services.ipynb",
+                            # This shouldn't run because services are missing
+                            "test-notebook-missing-service.ipynb",
+                            # This shouldn't run because the dir is excluded
+                            "some-dir/test-other-notebook-has-services.ipynb",
+                        ],
                         "working_directory": str(repo_path),
                     },
                 },
@@ -277,9 +368,12 @@ async def test_run_required_services(
     r = await client.get("/mobu/flocks/test/monkeys/bot-mobu-testuser1/log")
     assert r.status_code == 200
 
-    # Notebook with all services available
+    # Notebooks with all services available
     assert "Required services are available" in r.text
     assert "Final test" in r.text
+
+    # Should have been excluded by dir
+    assert "Required services are available - some-dir" not in r.text
 
     # Notebook with missing services
     assert "Required services are NOT available" not in r.text

--- a/tests/data/notebooks_services/some-dir/test-other-notebook-has-services.ipynb
+++ b/tests/data/notebooks_services/some-dir/test-other-notebook-has-services.ipynb
@@ -1,0 +1,64 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5cb3e0b7",
+   "metadata": {},
+   "source": [
+    "This is a test notebook to check the NotebookRunner business. It contains some Markdown cells and some code cells. Only the code cells should run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f84f0959",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Required services are available - some-dir\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53a941a4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Final test\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "823560c6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "mobu": {
+   "required_services": ["some_service"]
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
GitHub CI checks ask mobu to run an explicit list of notebooks. Some of these notebooks may be excluded once mobu picks up the job though.

This makes sure that these jobs runs the filtered notebooks in a single session.

Mobu could end up not actually running any notebooks, if all of the notebooks in the explicit list are excluded.  In this case, mobu will conclude the check as a success. A future PR will make mobu conclude the check as neutral in this case.