### PR TITLE
DM-48628: Add app metric event to EmptyLoop

### DIFF
--- a/changelog.d/20250129_095620_danfuchs_empty_loop_event.md
+++ b/changelog.d/20250129_095620_danfuchs_empty_loop_event.md
@@ -1,0 +1,3 @@
+### New features
+
+- Send an app metrics event for EmptyLoop iterations

--- a/src/mobu/events.py
+++ b/src/mobu/events.py
@@ -76,11 +76,20 @@ class TapQuery(EventBase):
     sync: bool
 
 
+class EmptyLoopExecution(EventBase):
+    """Reported when an empty loop... loops."""
+
+    success: bool
+
+
 class Events(EventMaker):
     """Container for app metrics event publishers."""
 
     @override
     async def initialize(self, manager: EventManager) -> None:
+        self.empty_loop = await manager.create_publisher(
+            "EmptyLoop", EmptyLoopExecution
+        )
         self.tap_query = await manager.create_publisher("tap_query", TapQuery)
         self.git_lfs_check = await manager.create_publisher(
             "git_lfs_check", GitLfsCheck

--- a/src/mobu/services/business/empty.py
+++ b/src/mobu/services/business/empty.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from mobu.events import EmptyLoopExecution
+
 from .base import Business
 
 __all__ = ["EmptyLoop"]
@@ -15,4 +17,6 @@ class EmptyLoop(Business):
     """
 
     async def execute(self) -> None:
-        pass
+        await self.events.empty_loop.publish(
+            EmptyLoopExecution(success=True, **self.common_event_attrs())
+        )

--- a/tests/business/emptyloop_test.py
+++ b/tests/business/emptyloop_test.py
@@ -1,0 +1,71 @@
+"""Tests for EmptyLoop."""
+
+from typing import cast
+from unittest.mock import ANY
+
+import pytest
+import respx
+from httpx import AsyncClient
+from safir.metrics import MockEventPublisher
+
+from mobu.events import Events
+
+from ..support.gafaelfawr import mock_gafaelfawr
+from ..support.util import wait_for_business
+
+
+@pytest.mark.asyncio
+async def test_run(
+    client: AsyncClient,
+    respx_mock: respx.Router,
+    events: Events,
+) -> None:
+    mock_gafaelfawr(respx_mock)
+
+    # Set up our mocked business
+    r = await client.put(
+        "/mobu/flocks",
+        json={
+            "name": "test",
+            "count": 1,
+            "user_spec": {"username_prefix": "bot-mobu-testuser"},
+            "scopes": ["exec:notebook"],
+            "business": {
+                "type": "EmptyLoop",
+            },
+        },
+    )
+
+    assert r.status_code == 201
+
+    # Wait until we've finished at least one loop,
+    # then check the results.
+    data = await wait_for_business(client, "bot-mobu-testuser1")
+    assert data == {
+        "name": "bot-mobu-testuser1",
+        "business": {
+            "failure_count": 0,
+            "name": "EmptyLoop",
+            "refreshing": False,
+            "success_count": 1,
+        },
+        "state": "RUNNING",
+        "user": {
+            "scopes": ["exec:notebook"],
+            "token": ANY,
+            "username": "bot-mobu-testuser1",
+        },
+    }
+
+    # Check events
+    published = cast(MockEventPublisher, events.empty_loop).published
+    published.assert_published_all(
+        [
+            {
+                "business": "EmptyLoop",
+                "flock": "test",
+                "success": True,
+                "username": "bot-mobu-testuser1",
+            }
+        ]
+    )


### PR DESCRIPTION
So we can track if Mobu concurrency rate is tanking during scale tests.