### PR TITLE
DM-48697: No autostart concurrency limit

### DIFF
--- a/changelog.d/20250131_113522_danfuchs_configurable_concurrency.md
+++ b/changelog.d/20250131_113522_danfuchs_configurable_concurrency.md
@@ -1,0 +1,3 @@
+### Other changes
+
+- Remove the limit from the autostart `aiojobs` `Scheduler`. Attempts to start a job past the limit resulted in jobs silently never starting. There are no cases where we would want to limit the autostart concurrency, so a limit is not needed.

--- a/src/mobu/services/manager.py
+++ b/src/mobu/services/manager.py
@@ -51,7 +51,7 @@ class FlockManager:
         self._events = events
         self._logger = logger
         self._flocks: dict[str, Flock] = {}
-        self._scheduler = Scheduler(limit=1000, pending_limit=0)
+        self._scheduler = Scheduler(limit=None, pending_limit=0)
 
     async def aclose(self) -> None:
         """Stop all flocks and free all resources."""


### PR DESCRIPTION
Remove the limit from the autostart `aiojobs` `Scheduler`. Attempts to start a job past the limit resulted in jobs silently never starting. There are no cases where we would want to limit the autostart concurrency, so a limit is not needed.