### PR TITLE
DM-48792: Create new QuerySet runner for SIAv2

### DIFF
--- a/changelog.d/20250205_175156_steliosvoutsinas_DM_48792.md
+++ b/changelog.d/20250205_175156_steliosvoutsinas_DM_48792.md
@@ -1,0 +1,5 @@
+<!-- Delete the sections that don't apply -->
+
+### New features
+
+- Add SIAv2 QuerySet runner which uses pyvo.search to query the dp0.2 SIAv2 Service

--- a/src/mobu/data/siaquerysetrunner/dp02/params.yaml
+++ b/src/mobu/data/siaquerysetrunner/dp02/params.yaml
@@ -1,0 +1,16 @@
+---
+# Limits for randomly selected points within the spatial extent of DP0.2.
+min_ra: 52.0
+max_ra: 72.0
+min_dec: -44.0
+max_dec: -28.0
+
+
+# Limits for randomly generated cones for DP0.2.
+min_radius: 0.003
+radius_range: 0.05
+
+
+# Limits for time parameter for DP0.2.
+start_time: 60550.31803461111
+end_time: 60550.31838182871

--- a/src/mobu/events.py
+++ b/src/mobu/events.py
@@ -76,6 +76,13 @@ class TapQuery(EventBase):
     sync: bool
 
 
+class SIAQuery(EventBase):
+    """Reported when a SIA query is executed."""
+
+    success: bool
+    duration: timedelta | None
+
+
 class EmptyLoopExecution(EventBase):
     """Reported when an empty loop... loops."""
 
@@ -91,6 +98,7 @@ class Events(EventMaker):
             "EmptyLoop", EmptyLoopExecution
         )
         self.tap_query = await manager.create_publisher("tap_query", TapQuery)
+        self.sia_query = await manager.create_publisher("sia_query", SIAQuery)
         self.git_lfs_check = await manager.create_publisher(
             "git_lfs_check", GitLfsCheck
         )

--- a/src/mobu/exceptions.py
+++ b/src/mobu/exceptions.py
@@ -19,6 +19,7 @@ __all__ = [
     "GitHubFileNotFoundError",
     "MonkeyNotFoundError",
     "NotRetainingLogsError",
+    "SIAClientError",
     "SubprocessError",
 ]
 
@@ -196,6 +197,18 @@ class JupyterSpawnError(Exception):
 
 class NotebookCellExecutionError(Exception):
     """Error when executing a notebook cell."""
+
+
+class SIAClientError(Exception):
+    """Creating an SIA client failed."""
+
+    def __init__(self, exc: Exception) -> None:
+        if str(exc):
+            error = f"{type(exc).__name__}: {exc!s}"
+        else:
+            error = type(exc).__name__
+        msg = f"Unable to create SIA client: {error}"
+        super().__init__(msg)
 
 
 class TAPClientError(Exception):

--- a/src/mobu/models/business/business_config_type.py
+++ b/src/mobu/models/business/business_config_type.py
@@ -6,6 +6,7 @@ from .empty import EmptyLoopConfig
 from .gitlfs import GitLFSConfig
 from .notebookrunner import NotebookRunnerConfig
 from .nubladopythonloop import NubladoPythonLoopConfig
+from .siaquerysetrunner import SIAQuerySetRunnerConfig
 from .tapqueryrunner import TAPQueryRunnerConfig
 from .tapquerysetrunner import TAPQuerySetRunnerConfig
 
@@ -15,6 +16,7 @@ BusinessConfigType: TypeAlias = (
     | NotebookRunnerConfig
     | NubladoPythonLoopConfig
     | TAPQuerySetRunnerConfig
+    | SIAQuerySetRunnerConfig
     | EmptyLoopConfig
 )
 """A union type alias of all of all busines config types."""

--- a/src/mobu/models/business/siaquerysetrunner.py
+++ b/src/mobu/models/business/siaquerysetrunner.py
@@ -1,0 +1,80 @@
+"""Models for the SIAQuerySetRunner monkey business."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from astropy.time import Time
+from pydantic import BaseModel, Field
+
+from .base import BusinessConfig, BusinessData, BusinessOptions
+
+__all__ = [
+    "SIABusinessData",
+    "SIAQuery",
+    "SIAQuerySetRunnerConfig",
+    "SIAQuerySetRunnerOptions",
+]
+
+
+class SIAQuerySetRunnerOptions(BusinessOptions):
+    """Options for SIAQuerySetRunner monkey business."""
+
+    query_set: str = Field(
+        "dp02",
+        title="Which query template set to use for a SIAQuerySetRunner",
+        examples=["dp02"],
+    )
+
+
+class SIAQuerySetRunnerConfig(BusinessConfig):
+    """Configuration specialization for SIAQuerySetRunner."""
+
+    type: Literal["SIAQuerySetRunner"] = Field(
+        ..., title="Type of business to run"
+    )
+
+    options: SIAQuerySetRunnerOptions = Field(
+        default_factory=SIAQuerySetRunnerOptions,
+        title="Options for the monkey business",
+    )
+
+
+class SIAQuery(BaseModel):
+    """The parameters of an SIA (v2) query."""
+
+    ra: float
+    dec: float
+    radius: float
+    time: list[float]
+
+    @property
+    def pos(self) -> tuple[float, float, float]:
+        return self.ra, self.dec, self.radius
+
+    def to_pyvo_sia_params(self) -> dict:
+        """Return the query as a dictionary in a form that
+        pyvo's SIA search expects it. We transform the time strings to
+        astropy Time objects and then to datetime.
+
+        Returns
+        -------
+            dict: The query as a dictionary.
+        """
+        times = [Time(str(t), format="mjd").to_datetime() for t in self.time]
+        return {"pos": self.pos, "time": times}
+
+    def __str__(self) -> str:
+        """Return a string representation of the query."""
+        times = ", ".join([str(t) for t in self.time])
+        return f"SIA parameters: pos={self.pos}, time=[{times}])"
+
+
+class SIABusinessData(BusinessData):
+    """Status of a running SIA business."""
+
+    running_query: SIAQuery | None = Field(
+        None,
+        title="Currently running query",
+        description="Will not be present if no query is being executed",
+    )

--- a/src/mobu/models/monkey.py
+++ b/src/mobu/models/monkey.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from .business.base import BusinessData
 from .business.notebookrunner import NotebookRunnerData
 from .business.nublado import NubladoBusinessData
+from .business.siaquerysetrunner import SIABusinessData
 from .business.tap import TAPBusinessData
 from .user import AuthenticatedUser
 
@@ -39,6 +40,7 @@ class MonkeyData(BaseModel):
     # its parent class.
     business: (
         TAPBusinessData
+        | SIABusinessData
         | NotebookRunnerData
         | NubladoBusinessData
         | BusinessData

--- a/src/mobu/services/business/siaquerysetrunner.py
+++ b/src/mobu/services/business/siaquerysetrunner.py
@@ -1,0 +1,201 @@
+"""Run a set of predefined queries against a SIA service."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.resources
+from concurrent.futures import ThreadPoolExecutor
+from random import SystemRandom
+from typing import override
+
+import pyvo
+import requests
+import yaml
+from safir.sentry import duration
+from sentry_sdk import set_context
+from structlog.stdlib import BoundLogger
+
+from ...dependencies.config import config_dependency
+from ...events import Events
+from ...events import SIAQuery as SIAQueryEvent
+from ...exceptions import SIAClientError
+from ...models.business.siaquerysetrunner import (
+    SIABusinessData,
+    SIAQuery,
+    SIAQuerySetRunnerOptions,
+)
+from ...models.user import AuthenticatedUser
+from ...sentry import capturing_start_span, start_transaction
+from .base import Business
+
+__all__ = ["SIAQuerySetRunner"]
+
+
+class SIAQuerySetRunner(Business):
+    """Run queries from a predefined set against SIA with random parameters.
+
+    Parameters
+    ----------
+    options
+        Configuration options for the business.
+    user
+        User with their authentication token to use to run the business.
+    events
+        Event publishers.
+    logger
+        Logger to use to report the results of business.
+    flock
+        Flock that is running this business, if it is running in a flock.
+    """
+
+    def __init__(
+        self,
+        *,
+        options: SIAQuerySetRunnerOptions,
+        user: AuthenticatedUser,
+        events: Events,
+        logger: BoundLogger,
+        flock: str | None,
+    ) -> None:
+        super().__init__(
+            options=options,
+            user=user,
+            events=events,
+            logger=logger,
+            flock=flock,
+        )
+        self._running_query: SIAQuery | None = None
+        self._client: pyvo.dal.SIA2Service | None = None
+        self._pool = ThreadPoolExecutor(max_workers=1)
+        self._random = SystemRandom()
+        self.query_set: str = self.options.query_set
+
+        # Load parameters. We don't need jinja here since we're not
+        # generating queries, just parameters from the ranges.
+        params_path = importlib.resources.files("mobu").joinpath(
+            "data", "siaquerysetrunner", self.options.query_set, "params.yaml"
+        )
+        with params_path.open("r") as f:
+            self._params = yaml.safe_load(f)
+
+    @override
+    async def startup(self) -> None:
+        self._client = self._make_client(self.user.token)
+        self.logger.info("Starting SIA Query Set Runner")
+
+    def get_next_query(self) -> SIAQuery:
+        """Get the next SIA query to run.
+
+        Returns
+        -------
+        SIA2SearchParameters
+            SIA query as an SIASearchParameters object.
+        """
+        return self._generate_sia_params()
+
+    @override
+    async def execute(self) -> None:
+        with start_transaction(
+            name=f"{self.name} - execute",
+            op="mobu.sia.search",
+        ):
+            query = self.get_next_query()
+            with capturing_start_span(op="mobu.sia.search") as span:
+                set_context(
+                    "query_info",
+                    {"query": str(query), "started_at": span.start_timestamp},
+                )
+                self._running_query = query
+
+                success = False
+                try:
+                    client = self._client
+                    if not client:
+                        raise RuntimeError(
+                            "SIAQuerySetRunner startup never ran"
+                        )
+                    self.logger.info(f"Running SIA query: {query}")
+                    loop = asyncio.get_event_loop()
+
+                    await loop.run_in_executor(
+                        self._pool,
+                        lambda: client.search(**query.to_pyvo_sia_params()),
+                    )
+                    success = True
+                finally:
+                    await self.events.sia_query.publish(
+                        payload=SIAQueryEvent(
+                            success=success,
+                            duration=duration(span),
+                            **self.common_event_attrs(),
+                        )
+                    )
+
+                self._running_query = None
+                elapsed = duration(span).total_seconds()
+
+            self.logger.info(f"Query finished after {elapsed} seconds")
+
+    @override
+    def dump(self) -> SIABusinessData:
+        return SIABusinessData(
+            running_query=self._running_query, **super().dump().model_dump()
+        )
+
+    def _make_client(self, token: str) -> pyvo.dal.SIA2Service:
+        """Create a SIA client.
+
+        Parameters
+        ----------
+        token
+            User authentication token.
+
+        Returns
+        -------
+        pyvo.dal.SIA2Service
+            SIA2Service client object.
+        """
+        with capturing_start_span(op="make_client"):
+            config = config_dependency.config
+            if not config.environment_url:
+                raise RuntimeError("environment_url not set")
+            sia_url = (
+                f"{str(config.environment_url).rstrip('/')}/api/sia/"
+                f"{self.query_set}"
+            )
+
+            try:
+                s = requests.Session()
+                s.headers["Authorization"] = "Bearer " + token
+                auth = pyvo.auth.AuthSession()
+                auth.credentials.set("lsst-token", s)
+                auth.add_security_method_for_url(
+                    sia_url + "/query", "lsst-token"
+                )
+                return pyvo.dal.SIA2Service(sia_url, auth)
+            except Exception as e:
+                raise SIAClientError(e) from e
+
+    def _generate_sia_params(
+        self,
+    ) -> SIAQuery:
+        """Generate a random SIA (v2) query."""
+        min_ra = self._params.get("min_ra", 55.0)
+        max_ra = self._params.get("max_ra", 70.0)
+        min_dec = self._params.get("min_dec", -42.0)
+        max_dec = self._params.get("max_dec", -30.0)
+        min_radius = self._params.get("min_radius", 0.01)
+        radius_range = self._params.get("radius_range", 0.04)
+        start_time = self._params.get("start_time", 60550.31803461111)
+        end_time = self._params.get("end_time", 60550.31838182871)
+
+        ra = min_ra + self._random.uniform(min_ra, max_ra)
+        dec = min_dec + self._random.uniform(min_dec, max_dec)
+        radius = self._random.uniform(min_radius, min_radius + radius_range)
+
+        return SIAQuery(
+            ra=ra,
+            dec=dec,
+            radius=radius,
+            time=[start_time, end_time],
+        )

--- a/src/mobu/services/monkey.py
+++ b/src/mobu/services/monkey.py
@@ -21,6 +21,7 @@ from ..models.business.empty import EmptyLoopConfig
 from ..models.business.gitlfs import GitLFSConfig
 from ..models.business.notebookrunner import NotebookRunnerConfig
 from ..models.business.nubladopythonloop import NubladoPythonLoopConfig
+from ..models.business.siaquerysetrunner import SIAQuerySetRunnerConfig
 from ..models.business.tapqueryrunner import TAPQueryRunnerConfig
 from ..models.business.tapquerysetrunner import TAPQuerySetRunnerConfig
 from ..models.monkey import MonkeyData, MonkeyState
@@ -31,6 +32,7 @@ from .business.empty import EmptyLoop
 from .business.gitlfs import GitLFSBusiness
 from .business.notebookrunner import NotebookRunner
 from .business.nubladopythonloop import NubladoPythonLoop
+from .business.siaquerysetrunner import SIAQuerySetRunner
 from .business.tapqueryrunner import TAPQueryRunner
 from .business.tapquerysetrunner import TAPQuerySetRunner
 
@@ -144,6 +146,14 @@ class Monkey:
             )
         elif isinstance(business_config, TAPQuerySetRunnerConfig):
             self.business = TAPQuerySetRunner(
+                options=business_config.options,
+                user=user,
+                events=self._events,
+                logger=self._logger,
+                flock=self._flock,
+            )
+        elif isinstance(business_config, SIAQuerySetRunnerConfig):
+            self.business = SIAQuerySetRunner(
                 options=business_config.options,
                 user=user,
                 events=self._events,

--- a/tests/business/siaquerysetrunner_test.py
+++ b/tests/business/siaquerysetrunner_test.py
@@ -1,0 +1,228 @@
+"""Tests for SIAQuerySetRunner."""
+
+from __future__ import annotations
+
+from typing import cast
+from unittest.mock import ANY, patch
+
+import pytest
+import pyvo
+import respx
+import structlog
+from anys import ANY_AWARE_DATETIME_STR, AnyContains, AnySearch, AnyWithEntries
+from httpx import AsyncClient
+from safir.metrics import NOT_NONE, MockEventPublisher
+from safir.testing.sentry import Captured
+
+from mobu.events import Events
+from mobu.models.business.siaquerysetrunner import SIAQuerySetRunnerOptions
+from mobu.models.user import AuthenticatedUser
+from mobu.services.business.siaquerysetrunner import SIAQuerySetRunner
+
+from ..support.gafaelfawr import mock_gafaelfawr
+from ..support.util import wait_for_business
+
+
+@pytest.mark.asyncio
+async def test_run(
+    client: AsyncClient, respx_mock: respx.Router, events: Events
+) -> None:
+    mock_gafaelfawr(respx_mock)
+
+    with patch.object(pyvo.dal, "SIA2Service"):
+        r = await client.put(
+            "/mobu/flocks",
+            json={
+                "name": "test",
+                "count": 1,
+                "user_spec": {"username_prefix": "bot-mobu-testuser"},
+                "scopes": ["exec:notebook"],
+                "business": {"type": "SIAQuerySetRunner"},
+            },
+        )
+        assert r.status_code == 201
+
+        # Wait until we've finished at least one loop and check the results.
+        data = await wait_for_business(client, "bot-mobu-testuser1")
+        assert data == {
+            "name": "bot-mobu-testuser1",
+            "business": {
+                "failure_count": 0,
+                "name": "SIAQuerySetRunner",
+                "refreshing": False,
+                "success_count": 1,
+            },
+            "state": "RUNNING",
+            "user": {
+                "scopes": ["exec:notebook"],
+                "token": ANY,
+                "username": "bot-mobu-testuser1",
+            },
+        }
+
+        # Get the log and check that we logged the query.
+        r = await client.get(
+            "/mobu/flocks/test/monkeys/bot-mobu-testuser1/log"
+        )
+        assert r.status_code == 200
+        assert "Running SIA query: " in r.text
+        assert "Query finished after " in r.text
+
+    # Confirm metrics events
+    published = cast(MockEventPublisher, events.sia_query).published
+    published.assert_published_all(
+        [
+            {
+                "business": "SIAQuerySetRunner",
+                "duration": NOT_NONE,
+                "flock": "test",
+                "success": True,
+                "username": "bot-mobu-testuser1",
+            }
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_error(
+    client: AsyncClient,
+    respx_mock: respx.Router,
+    sentry_items: Captured,
+) -> None:
+    """Test that client creation is deferred to setup.
+
+    This also doubles as a test that failures during setup are recorded as a
+    failed test execution and result in a Slack alert.
+    """
+    mock_gafaelfawr(respx_mock)
+
+    r = await client.put(
+        "/mobu/flocks",
+        json={
+            "name": "test",
+            "count": 1,
+            "users": [{"username": "bot-mobu-siauser"}],
+            "scopes": ["exec:notebook"],
+            "business": {"type": "SIAQuerySetRunner"},
+        },
+    )
+    assert r.status_code == 201
+
+    # Wait until we've finished at least one loop and check the results.
+    data = await wait_for_business(client, "bot-mobu-siauser")
+    assert data["business"]["failure_count"] == 1
+
+    # Confirm Sentry events
+    (sentry_error,) = sentry_items.errors
+
+    assert sentry_error["exception"]["values"] == AnyContains(
+        AnyWithEntries(
+            {
+                "type": "DALServiceError",
+                "value": "No working capabilities endpoint provided",
+            }
+        )
+    )
+    assert sentry_error["contexts"]["phase"] == {
+        "phase": "make_client",
+        "started_at": ANY_AWARE_DATETIME_STR,
+    }
+    assert sentry_error["tags"] == {
+        "flock": "test",
+        "business": "SIAQuerySetRunner",
+        "phase": "make_client",
+    }
+    assert sentry_error["user"] == {"username": "bot-mobu-siauser"}
+
+    (sentry_transaction,) = sentry_items.transactions
+    assert sentry_transaction["transaction"] == "SIAQuerySetRunner - startup"
+
+
+@pytest.mark.asyncio
+async def test_failure(
+    client: AsyncClient,
+    respx_mock: respx.Router,
+    events: Events,
+    sentry_items: Captured,
+) -> None:
+    mock_gafaelfawr(respx_mock)
+    with patch.object(pyvo.dal, "SIA2Service") as mock:
+        mock.return_value.search.side_effect = [Exception("some error")]
+
+        r = await client.put(
+            "/mobu/flocks",
+            json={
+                "name": "test",
+                "count": 1,
+                "user_spec": {"username_prefix": "bot-mobu-testuser"},
+                "scopes": ["exec:notebook"],
+                "business": {"type": "SIAQuerySetRunner"},
+            },
+        )
+        assert r.status_code == 201
+
+        # Wait until we've finished at least one loop and check the results.
+        data = await wait_for_business(client, "bot-mobu-testuser1")
+        assert data["business"]["failure_count"] == 1
+
+    # Confirm Sentry errors
+    (sentry_error,) = sentry_items.errors
+    assert sentry_error["contexts"]["phase"] == {
+        "phase": "mobu.sia.search",
+        "started_at": ANY_AWARE_DATETIME_STR,
+    }
+    assert sentry_error["contexts"]["query_info"] == {
+        "started_at": ANY_AWARE_DATETIME_STR,
+        "query": AnySearch("SIA parameters"),
+    }
+    assert sentry_error["tags"] == {
+        "flock": "test",
+        "business": "SIAQuerySetRunner",
+        "phase": "mobu.sia.search",
+    }
+    assert sentry_error["user"] == {"username": "bot-mobu-testuser1"}
+
+    (sentry_transaction,) = sentry_items.transactions
+    assert sentry_transaction["transaction"] == "SIAQuerySetRunner - execute"
+
+    # Confirm metrics events
+    published = cast(MockEventPublisher, events.sia_query).published
+    published.assert_published_all(
+        [
+            {
+                "business": "SIAQuerySetRunner",
+                "duration": NOT_NONE,
+                "flock": "test",
+                "success": False,
+                "username": "bot-mobu-testuser1",
+            }
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_random_object(events: Events) -> None:
+    query_set = "dp02"
+    user = AuthenticatedUser(
+        username="bot-mobu-user", scopes=["read:image"], token="blah blah"
+    )
+    logger = structlog.get_logger(__file__)
+    options = SIAQuerySetRunnerOptions(query_set=query_set)
+
+    with patch.object(pyvo.dal, "SIA2Service"):
+        runner = SIAQuerySetRunner(
+            options=options,
+            user=user,
+            events=events,
+            logger=logger,
+            flock=None,
+        )
+    parameters = runner._generate_sia_params()
+    assert parameters.ra >= 0.0
+    assert parameters.ra <= 360.0
+    assert parameters.dec >= -90.0
+    assert parameters.dec <= 90.0
+    assert parameters.radius >= 0.0
+    assert parameters.radius <= 1.0
+    assert parameters.pos == (parameters.ra, parameters.dec, parameters.radius)
+    assert len(parameters.time) == 2


### PR DESCRIPTION
### Summary 

Enables a new QuerySet runner in mobu for SIAv2 Queries. I've defined as range for ra dec & radius and a fixed time which I know should return results when querying the SIAv2 service. We may want to adjust this, but I don't know what options we want to add and this would require some consultation from Tim or a someone more familiar with the datasets and the available images for given query criteria.
This has been defined in a directory `dp02` under `data/siaquerysetrunner`. Reason for not going with dp0.2 is because I re-use this option to generate the URL for the given dataset, because the design of the SIA API is such that it includes the collection, i.e:

 `api/sia/dp02/query`

### Tests

Only some pytests added here, but have not tested on any environment yet.
