### PR TITLE
DM-48798: Config option to disable monkeys logging to file

### DIFF
--- a/src/mobu/config.py
+++ b/src/mobu/config.py
@@ -274,6 +274,15 @@ class Configuration(BaseSettings):
         title="Log level of the application's logger",
     )
 
+    log_monkeys_to_file: bool = Field(
+        True,
+        title="Log monkey messages to a file",
+        description=(
+            "Log monkey messages to a file instead of doing whatever the"
+            " normal global logger does"
+        ),
+    )
+
     metrics: MetricsConfiguration = Field(
         default_factory=metrics_configuration_factory,
         title="Metrics configuration",

--- a/src/mobu/exceptions.py
+++ b/src/mobu/exceptions.py
@@ -18,6 +18,7 @@ __all__ = [
     "GafaelfawrWebError",
     "GitHubFileNotFoundError",
     "MonkeyNotFoundError",
+    "NotRetainingLogsError",
     "SubprocessError",
 ]
 
@@ -92,6 +93,17 @@ class MonkeyNotFoundError(ClientRequestError):
         self.monkey = monkey
         msg = f"Monkey {monkey} not found"
         super().__init__(msg, ErrorLocation.path, ["monkey"])
+
+
+class NotRetainingLogsError(ClientRequestError):
+    """Mobu is not configured to retain logs."""
+
+    error = "mobu_not_retaining_logs"
+    status_code = status.HTTP_404_NOT_FOUND
+
+    def __init__(self) -> None:
+        msg = "Mobu is not configured to retain monkey logs"
+        super().__init__(msg)
 
 
 class NotebookRepositoryError(Exception):

--- a/src/mobu/services/monkey.py
+++ b/src/mobu/services/monkey.py
@@ -81,12 +81,16 @@ class Monkey:
         self._user = user
 
         self._state = MonkeyState.IDLE
-        self._logfile = NamedTemporaryFile()
-        self._logger = self._build_logger(self._logfile)
         self._global_logger = logger.bind(
             monkey=self._name, user=self._user.username
         )
         self._job: Job | None = None
+
+        self._logfile = NamedTemporaryFile()
+        if self._config.log_monkeys_to_file:
+            self._logger = self._build_logger(self._logfile)
+        else:
+            self._logger = self._global_logger
 
         # Determine the business class from the type of configuration we got,
         # which in turn will be based on Pydantic validation of the value of

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,12 @@ def _enable_github_ci_app(
 
 
 @pytest.fixture
+def _disable_file_logging() -> None:
+    """Disable monkey file logging."""
+    config_dependency.set_path(config_path("base_no_file_logging"))
+
+
+@pytest.fixture
 def _enable_github_refresh_app(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> Iterator[None]:

--- a/tests/data/config/base_no_file_logging.yaml
+++ b/tests/data/config/base_no_file_logging.yaml
@@ -1,0 +1,11 @@
+slackAlerts: true
+environmentUrl: "https://example.com"
+sentryEnvironment: "pytest"
+availableServices:
+  - some_service
+  - some_other_service
+metrics:
+  enabled: false
+  mock: true
+  appName: mobu
+logMonkeysToFile: false

--- a/tests/handlers/flock_test.py
+++ b/tests/handlers/flock_test.py
@@ -353,3 +353,24 @@ async def test_errors(client: AsyncClient, respx_mock: respx.Router) -> None:
         "msg": ANY,
         "type": "union_tag_invalid",
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_disable_file_logging")
+async def test_file_logging_disabled(
+    client: AsyncClient, respx_mock: respx.Router
+) -> None:
+    mock_gafaelfawr(respx_mock)
+
+    config = {
+        "name": "test",
+        "count": 1,
+        "user_spec": {"username_prefix": "bot-mobu-testuser"},
+        "scopes": ["exec:notebook"],
+        "business": {"type": "EmptyLoop"},
+    }
+    r = await client.put("/mobu/flocks", json=config)
+    assert r.status_code == 201
+
+    r = await client.get("/mobu/flocks/test/monkeys/bot-mobu-testuser1/log")
+    assert r.status_code == 404


### PR DESCRIPTION
Provides an option to have monkeys log to the global logger instead of a file logger. During scale testing, we may run into ephemeral storage limits when we have so many monkeys writing their logs to files. This lets us just log everything to stdout/err.