### PR TITLE
DM-48941: Only check out notebook repos once

### DIFF
--- a/changelog.d/20250217_173118_danfuchs_DM_48941.md
+++ b/changelog.d/20250217_173118_danfuchs_DM_48941.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Notebook repos are only cloned once per process (and once per refresh request), instead of once per monkey. This should speed up how fast NotebookRunner flocks start, especially in load testing usecases.

--- a/src/mobu/dependencies/context.py
+++ b/src/mobu/dependencies/context.py
@@ -19,6 +19,7 @@ from structlog.stdlib import BoundLogger
 from ..events import Events
 from ..factory import Factory, ProcessContext
 from ..services.manager import FlockManager
+from ..services.repo import RepoManager
 
 __all__ = [
     "ContextDependency",
@@ -40,6 +41,9 @@ class RequestContext:
 
     manager: FlockManager
     """Global singleton flock manager."""
+
+    repo_manager: RepoManager
+    """Global singleton git repo manager."""
 
     factory: Factory
     """Component factory."""
@@ -80,6 +84,7 @@ class ContextDependency:
             request=request,
             logger=logger,
             manager=self._process_context.manager,
+            repo_manager=self._process_context.repo_manager,
             factory=Factory(self._process_context, logger),
         )
 

--- a/src/mobu/dependencies/github.py
+++ b/src/mobu/dependencies/github.py
@@ -41,6 +41,7 @@ class CiManagerDependency:
             scopes=scopes,
             http_client=base_context.process_context.http_client,
             events=base_context.process_context.events,
+            repo_manager=base_context.process_context.repo_manager,
             gafaelfawr_storage=base_context.process_context.gafaelfawr,
             logger=base_context.process_context.logger,
         )

--- a/src/mobu/handlers/github_refresh_app.py
+++ b/src/mobu/handlers/github_refresh_app.py
@@ -71,10 +71,7 @@ async def post_webhook(
     context.logger.debug("Received GitHub webhook", payload=event.data)
     # Give GitHub some time to reach internal consistency.
     await asyncio.sleep(GITHUB_WEBHOOK_WAIT_SECONDS)
-    await gidgethub_router.dispatch(
-        event=event,
-        context=context,
-    )
+    await gidgethub_router.dispatch(event=event, context=context)
 
 
 @gidgethub_router.register("push")

--- a/src/mobu/models/repo.py
+++ b/src/mobu/models/repo.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = ["ClonedRepoInfo", "RepoConfig"]
 
 
 class RepoConfig(BaseModel):
@@ -25,3 +29,12 @@ class RepoConfig(BaseModel):
         ),
         examples=["some-dir", "some-dir/some-other-dir"],
     )
+
+
+@dataclass(frozen=True)
+class ClonedRepoInfo:
+    """Information about a cloned git repo."""
+
+    dir: TemporaryDirectory
+    path: Path
+    hash: str

--- a/src/mobu/services/flock.py
+++ b/src/mobu/services/flock.py
@@ -18,6 +18,7 @@ from ..models.business.notebookrunner import (
 )
 from ..models.flock import FlockConfig, FlockData, FlockSummary
 from ..models.user import AuthenticatedUser, User, UserSpec
+from ..services.repo import RepoManager
 from ..storage.gafaelfawr import GafaelfawrStorage
 from .monkey import Monkey
 
@@ -39,6 +40,8 @@ class Flock:
         Shared HTTP client.
     events
         Event publishers.
+    repo_manager
+        For efficiently cloning git repos.
     logger
         Global logger.
     """
@@ -51,6 +54,7 @@ class Flock:
         gafaelfawr_storage: GafaelfawrStorage,
         http_client: AsyncClient,
         events: Events,
+        repo_manager: RepoManager,
         logger: BoundLogger,
     ) -> None:
         self.name = flock_config.name
@@ -59,6 +63,7 @@ class Flock:
         self._gafaelfawr = gafaelfawr_storage
         self._http_client = http_client
         self._events = events
+        self._repo_manager = repo_manager
         self._logger = logger.bind(flock=self.name)
         self._monkeys: dict[str, Monkey] = {}
         self._start_time: datetime | None = None
@@ -166,6 +171,7 @@ class Flock:
             user=user,
             http_client=self._http_client,
             events=self._events,
+            repo_manager=self._repo_manager,
             logger=self._logger,
         )
 

--- a/src/mobu/services/github_ci/ci_manager.py
+++ b/src/mobu/services/github_ci/ci_manager.py
@@ -16,6 +16,7 @@ from ...dependencies.config import config_dependency
 from ...events import Events
 from ...models.ci_manager import CiManagerSummary, CiWorkerSummary
 from ...models.user import User
+from ...services.repo import RepoManager
 from ...storage.gafaelfawr import GafaelfawrStorage
 from ...storage.github import GitHubStorage
 from .ci_notebook_job import CiNotebookJob
@@ -79,6 +80,7 @@ class CiManager:
         users: list[User],
         http_client: AsyncClient,
         events: Events,
+        repo_manager: RepoManager,
         gafaelfawr_storage: GafaelfawrStorage,
         logger: BoundLogger,
     ) -> None:
@@ -88,6 +90,7 @@ class CiManager:
         self._gafaelfawr = gafaelfawr_storage
         self._http_client = http_client
         self._events = events
+        self._repo_manager = repo_manager
         self._logger = logger.bind(ci_manager=True)
         self._scheduler: Scheduler = Scheduler()
         self._queue: Queue[QueueItem] = Queue()
@@ -257,6 +260,7 @@ class CiManager:
             check_run=check_run,
             http_client=self._http_client,
             events=self._events,
+            repo_manager=self._repo_manager,
             logger=self._logger,
             gafaelfawr_storage=self._gafaelfawr,
         )

--- a/src/mobu/services/github_ci/ci_notebook_job.py
+++ b/src/mobu/services/github_ci/ci_notebook_job.py
@@ -13,6 +13,7 @@ from ...models.business.notebookrunner import (
 from ...models.ci_manager import CiJobSummary
 from ...models.solitary import SolitaryConfig
 from ...models.user import User
+from ...services.repo import RepoManager
 from ...services.solitary import Solitary
 from ...storage.gafaelfawr import GafaelfawrStorage
 from ...storage.github import CheckRun, GitHubStorage
@@ -44,6 +45,7 @@ class CiNotebookJob:
         check_run: CheckRun,
         http_client: AsyncClient,
         events: Events,
+        repo_manager: RepoManager,
         gafaelfawr_storage: GafaelfawrStorage,
         logger: BoundLogger,
     ) -> None:
@@ -51,6 +53,7 @@ class CiNotebookJob:
         self.check_run = check_run
         self._http_client = http_client
         self._events = events
+        self._repo_manager = repo_manager
         self._gafaelfawr = gafaelfawr_storage
         self._logger = logger.bind(ci_job_type="NotebookJob")
         self._notebooks: list[Path] = []
@@ -101,6 +104,7 @@ class CiNotebookJob:
             gafaelfawr_storage=self._gafaelfawr,
             http_client=self._http_client,
             events=self._events,
+            repo_manager=self._repo_manager,
             logger=self._logger,
         )
 

--- a/src/mobu/services/manager.py
+++ b/src/mobu/services/manager.py
@@ -12,6 +12,7 @@ from ..dependencies.config import config_dependency
 from ..events import Events
 from ..exceptions import FlockNotFoundError
 from ..models.flock import FlockConfig, FlockSummary
+from ..services.repo import RepoManager
 from ..storage.gafaelfawr import GafaelfawrStorage
 from .flock import Flock
 
@@ -33,6 +34,8 @@ class FlockManager:
         Shared HTTP client.
     events
         Event publishers.
+    repo_manager
+        For efficiently cloning git repos.
     logger
         Global logger to use for process-wide (not monkey) logging.
     """
@@ -43,12 +46,14 @@ class FlockManager:
         gafaelfawr_storage: GafaelfawrStorage,
         http_client: AsyncClient,
         events: Events,
+        repo_manager: RepoManager,
         logger: BoundLogger,
     ) -> None:
         self._config = config_dependency.config
         self._gafaelfawr = gafaelfawr_storage
         self._http_client = http_client
         self._events = events
+        self._repo_manager = repo_manager
         self._logger = logger
         self._flocks: dict[str, Flock] = {}
         self._scheduler = Scheduler(limit=None, pending_limit=0)
@@ -87,6 +92,7 @@ class FlockManager:
             gafaelfawr_storage=self._gafaelfawr,
             http_client=self._http_client,
             events=self._events,
+            repo_manager=self._repo_manager,
             logger=self._logger,
         )
         if flock.name in self._flocks:

--- a/src/mobu/services/monkey.py
+++ b/src/mobu/services/monkey.py
@@ -25,6 +25,7 @@ from ..models.business.tapqueryrunner import TAPQueryRunnerConfig
 from ..models.business.tapquerysetrunner import TAPQuerySetRunnerConfig
 from ..models.monkey import MonkeyData, MonkeyState
 from ..models.user import AuthenticatedUser
+from ..services.repo import RepoManager
 from .business.base import Business
 from .business.empty import EmptyLoop
 from .business.gitlfs import GitLFSBusiness
@@ -56,6 +57,8 @@ class Monkey:
         Shared HTTP client.
     events
         Event publishers.
+    repo_manager
+        For efficiently cloning git repos.
     logger
         Global logger.
     """
@@ -69,6 +72,7 @@ class Monkey:
         user: AuthenticatedUser,
         http_client: AsyncClient,
         events: Events,
+        repo_manager: RepoManager,
         logger: BoundLogger,
     ) -> None:
         self._config = config_dependency.config
@@ -78,6 +82,7 @@ class Monkey:
         self._log_level = business_config.options.log_level
         self._http_client = http_client
         self._events = events
+        self._repo_manager = repo_manager
         self._user = user
 
         self._state = MonkeyState.IDLE
@@ -125,6 +130,7 @@ class Monkey:
                 options=business_config.options,
                 user=user,
                 events=self._events,
+                repo_manager=self._repo_manager,
                 logger=self._logger,
                 flock=self._flock,
             )

--- a/src/mobu/services/repo.py
+++ b/src/mobu/services/repo.py
@@ -1,0 +1,169 @@
+"""Helpers for cloning and filtering notebook repos."""
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from structlog.stdlib import BoundLogger
+
+from ..models.repo import ClonedRepoInfo
+from ..sentry import capturing_start_span
+from ..storage.git import Git
+
+__all__ = ["RepoManager"]
+
+
+@dataclass(frozen=True)
+class _Key:
+    """Information to hash a repo clone."""
+
+    url: str
+    ref: str
+
+
+@dataclass(frozen=True)
+class _Reference:
+    """Information to hash a repo clone."""
+
+    url: str
+    ref: str
+    hash: str
+
+
+@dataclass
+class _ReferenceCount:
+    """A count and a directory to remove when the count reaches 0."""
+
+    count: int
+    dir: TemporaryDirectory
+
+
+class RepoManager:
+    """A reference-counting caching repo cloner.
+
+    Only the first call to ``clone`` for a given repo url and ref will clone
+    the repo. Subsequent calls will return the location and hash of the
+    already-cloned repo.
+
+    A call to ``invalidate`` will make it so that the next call to ``clone``
+    will re-clone the repo to a different path.
+
+    A call to ``clone`` also increases a reference counter for the url + ref +
+    hash combo of the cloned repo. A call to ``invalidate`` for that combo
+    decreases the counter. ``Invalidate`` will only delete the files from the
+    cloned repo if the reference count drops to 0.
+
+    Parameters
+    ----------
+    logger
+        A logger
+    """
+
+    def __init__(self, logger: BoundLogger, *, testing: bool = False) -> None:
+        self._dir = TemporaryDirectory(delete=False, prefix="mobu-notebooks-")
+        self._cache: dict[_Key, ClonedRepoInfo] = {}
+        self._lock = asyncio.Lock()
+        self._logger = logger
+        self._references: dict[_Reference, _ReferenceCount] = {}
+        self._testing = testing
+
+        # This is just for testing
+        self._cloned: list[_Key] = []
+
+    async def clone(self, url: str, ref: str) -> ClonedRepoInfo:
+        """Clone a git repo or return cached info by url + ref.
+
+        Increase the reference count for the url + ref + hash combo.
+
+        Parameters
+        ----------
+        url
+            The URL of the repo to clone
+        ref
+            The git ref to checkout after the repo is cloned
+        """
+        logger = self._logger.bind(url=url, ref=ref)
+        key = _Key(url=url, ref=ref)
+
+        async with self._lock:
+            # If the notebook repo has already been cloned, return the info
+            if info := self._cache.get(key):
+                logger.info("Notebook repo cached")
+                reference = _Reference(url=url, ref=ref, hash=info.hash)
+                count = self._references[reference]
+                count.count += 1
+                return info
+
+            # If not, clone the repo
+            logger.info("Cloning notebook repo")
+            repo_dir = TemporaryDirectory(delete=False, dir=self._dir.name)
+            with capturing_start_span(op="clone_repo"):
+                git = Git(logger=self._logger)
+                git.repo = Path(repo_dir.name)
+                await git.clone(url, repo_dir.name)
+                await git.checkout(ref)
+                repo_hash = await git.repo_hash()
+
+            # If we're in testing mode, record that we actually did a clone
+            if self._testing:
+                self._cloned.append(key)
+
+            info = ClonedRepoInfo(
+                dir=repo_dir, path=Path(repo_dir.name), hash=repo_hash
+            )
+
+            # Update the cache with the cloned repo's info
+            self._cache[key] = info
+
+            # Update the reference count
+            reference = _Reference(url=url, ref=ref, hash=info.hash)
+            self._references[reference] = _ReferenceCount(
+                count=1, dir=info.dir
+            )
+            return info
+
+    async def invalidate(self, url: str, ref: str, repo_hash: str) -> None:
+        """Invalidate a git repo in the cache by url + ref.
+
+        Decrease the url + ref + hash reference count. If it drops to zero,
+        delete the files from that clone.
+
+        Parameters
+        ----------
+        url
+            The URL of the repo to clone
+        ref
+            The git ref to checkout after the repo is cloned
+        hash
+            The hash of the cloned repo to remove
+        """
+        logger = self._logger.bind(url=url, ref=ref, hash=repo_hash)
+        key = _Key(url=url, ref=ref)
+        reference = _Reference(url=url, ref=ref, hash=repo_hash)
+
+        # This theoretically doesn't need a lock, but if we add any awaits here
+        # in the future, we'd need to add a lock, and it would be pretty easy
+        # to forget to do it.
+        async with self._lock:
+            info = self._cache.get(key)
+            if info:
+                logger.info("Invalidating repo")
+
+                # Note that this could force an unnecessary clone if any monkey
+                # is calling invalidate in its shutdown method. This would
+                # force reclone for other monkeys that are using the same repo
+                # at the same hash.
+                del self._cache[key]
+
+            count = self._references.get(reference)
+            if count:
+                count.count -= 1
+                if count.count == 0:
+                    logger.info(f"0 references, deleting: {count.dir.name}")
+                    count.dir.cleanup()
+                    del self._references[reference]
+
+    def close(self) -> None:
+        """Delete all cloned repos and containing directory."""
+        self._dir.cleanup()

--- a/src/mobu/services/solitary.py
+++ b/src/mobu/services/solitary.py
@@ -9,6 +9,7 @@ from structlog.stdlib import BoundLogger
 
 from ..events import Events
 from ..models.solitary import SolitaryConfig, SolitaryResult
+from ..services.repo import RepoManager
 from ..storage.gafaelfawr import GafaelfawrStorage
 from .monkey import Monkey
 
@@ -28,6 +29,8 @@ class Solitary:
         Shared HTTP client.
     events
         Event publishers.
+    repo_manager
+        For efficiently cloning git repos.
     logger
         Global logger.
     """
@@ -39,12 +42,14 @@ class Solitary:
         gafaelfawr_storage: GafaelfawrStorage,
         http_client: AsyncClient,
         events: Events,
+        repo_manager: RepoManager,
         logger: BoundLogger,
     ) -> None:
         self._config = solitary_config
         self._gafaelfawr = gafaelfawr_storage
         self._http_client = http_client
         self._events = events
+        self._repo_manager = repo_manager
         self._logger = logger
 
     async def run(self) -> SolitaryResult:
@@ -64,6 +69,7 @@ class Solitary:
             user=user,
             http_client=self._http_client,
             events=self._events,
+            repo_manager=self._repo_manager,
             logger=self._logger,
         )
         error = await monkey.run_once()

--- a/tests/services/ci_manager_test.py
+++ b/tests/services/ci_manager_test.py
@@ -18,6 +18,7 @@ from mobu.models.ci_manager import (
 from mobu.models.user import User
 from mobu.services.business.base import Business
 from mobu.services.github_ci.ci_manager import CiManager
+from mobu.services.repo import RepoManager
 from mobu.storage.gafaelfawr import GafaelfawrStorage
 from tests.support.constants import TEST_GITHUB_CI_APP_PRIVATE_KEY
 
@@ -41,11 +42,13 @@ def create_ci_manager(respx_mock: respx.Router, events: Events) -> CiManager:
     http_client = AsyncClient()
     logger = structlog.get_logger()
     gafaelfawr = GafaelfawrStorage(http_client=http_client, logger=logger)
+    repo_manager = RepoManager(logger=logger)
 
     return CiManager(
         http_client=http_client,
         gafaelfawr_storage=gafaelfawr,
         events=events,
+        repo_manager=repo_manager,
         logger=logger,
         scopes=scopes,
         github_app_id=123,

--- a/tests/services/repo_cache_test.py
+++ b/tests/services/repo_cache_test.py
@@ -1,0 +1,128 @@
+"""Tests for the RepoCache."""
+
+import shutil
+from asyncio import gather
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from mobu.services.repo import RepoManager
+from mobu.storage.git import Git
+
+from ..support.constants import TEST_DATA_DIR
+
+
+async def setup_git_repo(repo_path: Path) -> str:
+    """Initialize and populate a git repo at `repo_path`.
+
+    Returns
+    -------
+    str
+        Commit hash of the cloned repo
+    """
+    git = Git(repo=repo_path)
+    await git.init("--initial-branch=main")
+    await git.config("user.email", "gituser@example.com")
+    await git.config("user.name", "Git User")
+    for path in repo_path.iterdir():
+        if not path.name.startswith("."):
+            await git.add(str(path))
+    await git.commit("-m", "Initial commit")
+    return await git.repo_hash()
+
+
+@pytest.mark.asyncio
+async def test_cache(
+    tmp_path: Path,
+) -> None:
+    # Set up a notebook repository.
+    source_path = TEST_DATA_DIR / "notebooks"
+    repo_path = tmp_path / "notebooks"
+    repo_ref = "main"
+
+    shutil.copytree(str(source_path), str(repo_path))
+    await setup_git_repo(repo_path)
+
+    mock_logger = MagicMock()
+    manager = RepoManager(logger=mock_logger, testing=True)
+
+    # Clone the same repo and ref a bunch of times concurrently
+    clone_tasks = [
+        manager.clone(url=str(repo_path), ref=repo_ref) for _ in range(100)
+    ]
+    infos = await gather(*clone_tasks)
+
+    # The same info should be returned for every call
+    assert len(set(infos)) == 1
+    original_info = infos[0]
+
+    # The repo should have been cloned
+    contents = (original_info.path / "test-notebook.ipynb").read_text()
+    assert "This is a test" in contents
+    assert "This is a NEW test" not in contents
+
+    # ...once
+    assert len(manager._cloned) == 1
+    manager._cloned = []
+
+    # Change the notebook and git commit it
+    notebook = repo_path / "test-notebook.ipynb"
+    contents = notebook.read_text()
+    new_contents = contents.replace("This is a test", "This is a NEW test")
+    notebook.write_text(new_contents)
+
+    git = Git(repo=repo_path)
+    await git.add(str(notebook))
+    await git.commit("-m", "Updating notebook")
+
+    # The repo should be cached (this makes the reference count 101)
+    cached_info = await manager.clone(url=str(repo_path), ref=repo_ref)
+    assert cached_info == original_info
+    contents = (cached_info.path / "test-notebook.ipynb").read_text()
+    assert "This is a test" in contents
+    assert "This is a NEW test" not in contents
+
+    # Invalidate this URL and ref. This should make the next clone call clone
+    # the repo again, but it should not delete the directory of the old
+    # checkout because there are still 100 references to it.
+    await manager.invalidate(
+        url=str(repo_path), ref=repo_ref, repo_hash=original_info.hash
+    )
+
+    # Clone it again and verify stuff
+    clone_tasks = [
+        manager.clone(url=str(repo_path), ref=repo_ref) for _ in range(100)
+    ]
+    infos = await gather(*clone_tasks)
+    assert len(set(infos)) == 1
+    assert len(manager._cloned) == 1
+    updated_info = infos[0]
+
+    # We should get different info because the repo should have been recloned
+    assert updated_info != original_info
+
+    # The repo should be updated
+    contents = (updated_info.path / "test-notebook.ipynb").read_text()
+    assert "This is a test" not in contents
+    assert "This is a NEW test" in contents
+
+    # The original dir should NOT be deleted
+    assert Path(original_info.dir.name).exists()
+
+    # invalidate the other references
+    remove_tasks = [
+        manager.invalidate(
+            url=str(repo_path), ref=repo_ref, repo_hash=original_info.hash
+        )
+        for _ in range(100)
+    ]
+    await gather(*remove_tasks)
+
+    # The original dir should be deleted
+    assert not Path(original_info.dir.name).exists()
+
+    # The cache should clean up after itself
+    manager.close()
+    assert not original_info.path.exists()
+    assert not updated_info.path.exists()


### PR DESCRIPTION
Add a process-global notebook repo cache. Use this in the NotebookRunner business to only clone notebook repos once per process, not once per monkey.

The notebook repo refresh functionality complicates this a bit, see [this comment](https://github.com/lsst-sqre/mobu/pull/407#issue-2854417705)