### PR TITLE
DM-48977: Update Dockerfile to use uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,28 +20,29 @@ RUN ./install-base-packages.sh && rm ./install-base-packages.sh
 
 FROM base-image AS install-image
 
+# Install uv.
+COPY --from=ghcr.io/astral-sh/uv:0.6.1 /uv /bin/uv
+
 # Install system packages only needed for building dependencies.
 COPY scripts/install-dependency-packages.sh .
 RUN ./install-dependency-packages.sh
 
 # Create a Python virtual environment
 ENV VIRTUAL_ENV=/opt/venv
-RUN python -m venv $VIRTUAL_ENV
+RUN uv venv $VIRTUAL_ENV
 
 # Make sure we use the virtualenv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Put the latest pip and setuptools in the virtualenv
-RUN pip install --upgrade --no-cache-dir pip setuptools wheel
-
 # Install the app's Python runtime dependencies
 COPY requirements/main.txt ./requirements.txt
-RUN pip install --quiet --no-cache-dir -r requirements.txt
+RUN uv pip install --compile-bytecode --verify-hashes --no-cache \
+    -r requirements.txt
 
 # Install the application.
 COPY . /workdir
 WORKDIR /workdir
-RUN pip install --no-cache-dir .
+RUN uv pip install --compile-bytecode --no-cache .
 
 FROM base-image AS runtime-image
 
@@ -61,4 +62,4 @@ USER appuser
 EXPOSE 8080
 
 # Run the application.
-CMD ["uvicorn", "mobu.main:create_app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "--factory", "mobu.main:create_app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
Use uv to install Python packages in the Docker image. Add the `--factory` flag to `uvicorn` since the named object is a callable and not an ASGI server object.