### PR TITLE
DM-48977: Switch to new Python type variable syntax

### DIFF
--- a/changelog.d/20250217_150229_rra_DM_48977.md
+++ b/changelog.d/20250217_150229_rra_DM_48977.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Fix jitter calculations in Nublado businesses.

--- a/src/mobu/asyncio.py
+++ b/src/mobu/asyncio.py
@@ -9,9 +9,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
 from contextlib import AbstractAsyncContextManager
 from datetime import timedelta
 from types import TracebackType
-from typing import Literal, TypeVar
-
-T = TypeVar("T")
+from typing import Literal
 
 __all__ = [
     "aclosing_iter",
@@ -88,7 +86,7 @@ def schedule_periodic(
     return asyncio.ensure_future(loop())
 
 
-async def wait_first(*args: Coroutine[None, None, T]) -> T | None:
+async def wait_first[T](*args: Coroutine[None, None, T]) -> T | None:
     """Return the result of the first awaitable to finish.
 
     The other awaitables will be cancelled.  The first awaitable determines

--- a/src/mobu/services/business/base.py
+++ b/src/mobu/services/business/base.py
@@ -8,7 +8,7 @@ from asyncio import Queue, QueueEmpty
 from collections.abc import AsyncGenerator, AsyncIterable
 from datetime import timedelta
 from enum import Enum
-from typing import Generic, TypedDict, TypeVar
+from typing import TypedDict
 
 from safir.datetime import current_datetime
 from structlog.stdlib import BoundLogger
@@ -18,9 +18,6 @@ from ...events import Events
 from ...models.business.base import BusinessData, BusinessOptions
 from ...models.user import AuthenticatedUser
 from ...sentry import capturing_start_span, start_transaction
-
-T = TypeVar("T", bound="BusinessOptions")
-U = TypeVar("U")
 
 __all__ = ["Business"]
 
@@ -37,7 +34,7 @@ class BusinessCommand(Enum):
     STOP = "STOP"
 
 
-class Business(Generic[T], metaclass=ABCMeta):
+class Business[T: BusinessOptions](metaclass=ABCMeta):
     """Base class for monkey business (one type of repeated operation).
 
     The basic flow for a monkey business is as follows:
@@ -114,21 +111,21 @@ class Business(Generic[T], metaclass=ABCMeta):
 
     # Methods that should be overridden by child classes if needed.
 
-    async def startup(self) -> None:
+    async def startup(self) -> None:  # noqa: B027
         """Run before the start of the first iteration and then not again."""
 
     @abstractmethod
     async def execute(self) -> None:
         """Execute the core of each business loop."""
 
-    async def close(self) -> None:
+    async def close(self) -> None:  # noqa: B027
         """Clean up any allocated resources.
 
         This should be overridden by child classes to free any resources that
         were allocated in ``__init__``.
         """
 
-    async def shutdown(self) -> None:
+    async def shutdown(self) -> None:  # noqa: B027
         """Perform any cleanup required after stopping."""
 
     # Public Business API called by the Monkey class. These methods handle the
@@ -258,7 +255,7 @@ class Business(Generic[T], metaclass=ABCMeta):
         except (TimeoutError, QueueEmpty):
             return True
 
-    async def iter_with_timeout(
+    async def iter_with_timeout[U](
         self, iterable: AsyncIterable[U], timeout: timedelta
     ) -> AsyncGenerator[U]:
         """Run an iterator with a timeout.

--- a/src/mobu/services/business/tap.py
+++ b/src/mobu/services/business/tap.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 from abc import ABCMeta, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
-from typing import Generic, TypeVar
 
 import pyvo
 import requests
@@ -21,12 +20,10 @@ from ...models.user import AuthenticatedUser
 from ...sentry import capturing_start_span, start_transaction
 from .base import Business
 
-T = TypeVar("T", bound="TAPBusinessOptions")
-
 __all__ = ["TAPBusiness"]
 
 
-class TAPBusiness(Business, Generic[T], metaclass=ABCMeta):
+class TAPBusiness[T: TAPBusinessOptions](Business[T], metaclass=ABCMeta):
     """Base class for business that executes TAP query.
 
     This class modifies the core `~mobu.business.base.Business` loop by


### PR DESCRIPTION
Switch to the new Python syntax for generic parameters to classes and functions. This apparently unconfused mypy and Ruff enough that it uncovered some additional diagnostics, which required some `noqa` comments and some code refactoring, one to fix a bug and another to unconfuse the type checker.