### PR TITLE
DM-48977: Use datetime.now instead of current_datetime

### DIFF
--- a/src/mobu/services/business/nublado.py
+++ b/src/mobu/services/business/nublado.py
@@ -7,13 +7,13 @@ from abc import ABCMeta, abstractmethod
 from collections.abc import AsyncGenerator
 from contextlib import aclosing, asynccontextmanager
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from random import SystemRandom
 from typing import Any, override
 
 import sentry_sdk
 from rubin.nublado.client import JupyterLabSession, NubladoClient
-from safir.datetime import current_datetime, format_datetime_for_logging
+from safir.datetime import format_datetime_for_logging
 from safir.sentry import duration
 from sentry_sdk import set_tag
 from sentry_sdk.tracing import Span
@@ -67,9 +67,7 @@ class ProgressLogMessage:
     message: str
     """The message."""
 
-    timestamp: datetime = field(
-        default_factory=lambda: current_datetime(microseconds=True)
-    )
+    timestamp: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
     """When the event was received."""
 
     def __str__(self) -> str:
@@ -397,9 +395,9 @@ class NubladoBusiness[T: NubladoBusinessOptions](
         # If we're not stopping, wait for the lab to actually go away.  If
         # we don't do this, we may try to create a new lab while the old
         # one is still shutting down.
-        start = current_datetime(microseconds=True)
+        start = datetime.now(tz=UTC)
         while not await self._client.is_lab_stopped():
-            elapsed = current_datetime(microseconds=True) - start
+            elapsed = datetime.now(tz=UTC) - start
             elapsed_seconds = round(elapsed.total_seconds())
             if elapsed > self.options.delete_timeout:
                 if not await self._client.is_lab_stopped(log_running=True):

--- a/src/mobu/services/flock.py
+++ b/src/mobu/services/flock.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import math
-from datetime import datetime
+from datetime import UTC, datetime
 
 from aiojobs import Scheduler
 from httpx import AsyncClient
-from safir.datetime import current_datetime
 from structlog.stdlib import BoundLogger
 
 from ..events import Events
@@ -126,7 +125,7 @@ class Flock:
             monkey = self._create_monkey(user)
             self._monkeys[user.username] = monkey
             await monkey.start(self._scheduler)
-        self._start_time = current_datetime(microseconds=True)
+        self._start_time = datetime.now(tz=UTC)
 
     async def stop(self) -> None:
         """Stop all the monkeys.


### PR DESCRIPTION
Replace calls to `current_datetime(microseconds=True)` with the more native Python library call `datetime.now(tz=UTC)`, which didn't exist when the former was written.