### PR TITLE
DM-48977: Rename Configuration to Config

### DIFF
--- a/src/mobu/config.py
+++ b/src/mobu/config.py
@@ -18,7 +18,7 @@ from mobu.models.flock import FlockConfig
 from .models.user import User
 
 __all__ = [
-    "Configuration",
+    "Config",
     "GitHubCiAppConfig",
     "GitHubRefreshAppConfig",
 ]
@@ -140,7 +140,7 @@ class GitHubRefreshAppConfig(BaseSettings):
     )
 
 
-class Configuration(BaseSettings):
+class Config(BaseSettings):
     """Configuration for mobu."""
 
     model_config = SettingsConfigDict(

--- a/src/mobu/dependencies/config.py
+++ b/src/mobu/dependencies/config.py
@@ -3,7 +3,7 @@
 import os
 from pathlib import Path
 
-from ..config import Configuration
+from ..config import Config
 from ..constants import CONFIGURATION_PATH
 
 __all__ = [
@@ -32,16 +32,16 @@ class ConfigDependency:
         if test_path := os.environ.get("MOBU_CONFIG_PATH"):
             path = Path(test_path)
         self._path = path
-        self._config: Configuration | None = None
+        self._config: Config | None = None
 
-    async def __call__(self) -> Configuration:
+    async def __call__(self) -> Config:
         return self.config
 
     @property
-    def config(self) -> Configuration:
+    def config(self) -> Config:
         """Load configuration if needed and return it."""
         if self._config is None:
-            self._config = Configuration.from_file(self._path)
+            self._config = Config.from_file(self._path)
         return self._config
 
     @property
@@ -58,7 +58,7 @@ class ConfigDependency:
             New configuration path.
         """
         self._path = path
-        self._config = Configuration.from_file(path)
+        self._config = Config.from_file(path)
 
 
 config_dependency = ConfigDependency()

--- a/src/mobu/handlers/external.py
+++ b/src/mobu/handlers/external.py
@@ -12,7 +12,7 @@ from safir.metadata import get_metadata
 from safir.models import ErrorModel
 from safir.slack.webhook import SlackRouteErrorHandler
 
-from mobu.config import Configuration
+from mobu.config import Config
 from mobu.exceptions import NotRetainingLogsError
 
 from ..dependencies.config import config_dependency
@@ -53,7 +53,7 @@ class FormattedJSONResponse(JSONResponse):
     summary="Application metadata",
 )
 async def get_index(
-    config: Annotated[Configuration, Depends(config_dependency)],
+    config: Annotated[Config, Depends(config_dependency)],
 ) -> Index:
     metadata = get_metadata(
         package_name="mobu",
@@ -185,7 +185,7 @@ async def get_monkey(
 def get_monkey_log(
     flock: str,
     monkey: str,
-    config: Annotated[Configuration, Depends(config_dependency)],
+    config: Annotated[Config, Depends(config_dependency)],
     context: Annotated[RequestContext, Depends(context_dependency)],
 ) -> StreamingResponse:
     if not config.log_monkeys_to_file:

--- a/src/mobu/handlers/github_ci_app.py
+++ b/src/mobu/handlers/github_ci_app.py
@@ -12,7 +12,7 @@ from safir.github.webhooks import (
 )
 from safir.slack.webhook import SlackRouteErrorHandler
 
-from ..config import Configuration
+from ..config import Config
 from ..constants import GITHUB_WEBHOOK_WAIT_SECONDS
 from ..dependencies.config import config_dependency
 from ..dependencies.context import RequestContext, anonymous_context_dependency
@@ -37,7 +37,7 @@ gidgethub_router = routing.Router()
 )
 async def post_webhook(
     context: Annotated[RequestContext, Depends(anonymous_context_dependency)],
-    config: Annotated[Configuration, Depends(config_dependency)],
+    config: Annotated[Config, Depends(config_dependency)],
     ci_manager: Annotated[CiManager, Depends(ci_manager_dependency)],
 ) -> None:
     """Process GitHub webhook events for the mobu CI GitHubApp.

--- a/src/mobu/handlers/github_refresh_app.py
+++ b/src/mobu/handlers/github_refresh_app.py
@@ -9,7 +9,7 @@ from gidgethub.sansio import Event
 from safir.github.webhooks import GitHubPushEventModel
 from safir.slack.webhook import SlackRouteErrorHandler
 
-from ..config import Configuration
+from ..config import Config
 from ..constants import GITHUB_WEBHOOK_WAIT_SECONDS
 from ..dependencies.config import config_dependency
 from ..dependencies.context import RequestContext, anonymous_context_dependency
@@ -32,7 +32,7 @@ gidgethub_router = routing.Router()
 )
 async def post_webhook(
     context: Annotated[RequestContext, Depends(anonymous_context_dependency)],
-    config: Annotated[Configuration, Depends(config_dependency)],
+    config: Annotated[Config, Depends(config_dependency)],
 ) -> None:
     """Process GitHub webhook events for the mobu refresh GitHub app.
 

--- a/src/mobu/handlers/internal.py
+++ b/src/mobu/handlers/internal.py
@@ -13,7 +13,7 @@ from fastapi import APIRouter, Depends
 from safir.metadata import Metadata, get_metadata
 from safir.slack.webhook import SlackRouteErrorHandler
 
-from ..config import Configuration
+from ..config import Config
 from ..dependencies.config import config_dependency
 
 internal_router = APIRouter(route_class=SlackRouteErrorHandler)
@@ -33,7 +33,7 @@ __all__ = ["internal_router"]
     summary="Application metadata",
 )
 async def get_index(
-    config: Annotated[Configuration, Depends(config_dependency)],
+    config: Annotated[Config, Depends(config_dependency)],
 ) -> Metadata:
     return get_metadata(
         package_name="mobu",


### PR DESCRIPTION
Follow our current standard for naming of the global configuration class and rename `Configuration` to `Config`.