### PR TITLE
DM-48977: Remove unneeded Black configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,5 +17,5 @@ repos:
     rev: 1.19.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==24.3.0]
-        args: [-l, '79', -t, py312]
+        additional_dependencies: [black==25.1.0]
+        args: [-l, '79', -t, py313]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,25 +52,9 @@ Source = "https://github.com/lsst-sqre/mobu"
 requires = ["setuptools>=61", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools_scm]
-
 [tool.black]
 line-length = 79
-target-version = ["py312"]
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | build
-  | dist
-)/
-'''
-# Use single-quoted strings so TOML treats the string like a Python r-string
-# Multi-line strings are implicitly treated by black as regular expressions
+target-version = ["py313"]
 
 [tool.coverage.run]
 parallel = true
@@ -145,7 +129,7 @@ extend = "ruff-shared.toml"
     "ASYNC110", # TAP code could be rewritten to poll state differently
 ]
 "src/mobu/services/monkey.py" = [
-    "SIM115", # We do want a NamedTemporaryFile not in a context manager
+    "SIM115",   # we do want a NamedTemporaryFile not in a context manager
 ]
 "tests/data/**/*.ipynb" = [
     "T201",     # test notebooks are allowed to use print
@@ -167,3 +151,5 @@ format = "md"
 md_header_level = "2"
 new_fragment_template = "file:changelog.d/_template.md"
 skip_fragments = "_template.md"
+
+[tool.setuptools_scm]


### PR DESCRIPTION
Now that we use Ruff to do most code formatting, remove the Black file ignore configuration. Update the version of Black used for the pre-commit blacken-docs hook.