### PR TITLE
DM-48977: Treat the Slack alert webhook as a secret

### DIFF
--- a/src/mobu/config.py
+++ b/src/mobu/config.py
@@ -7,7 +7,7 @@ from textwrap import dedent
 from typing import Literal, Self
 
 import yaml
-from pydantic import AliasChoices, Field, HttpUrl
+from pydantic import AliasChoices, Field, HttpUrl, SecretStr
 from pydantic.alias_generators import to_camel
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from safir.logging import LogLevel, Profile
@@ -156,13 +156,10 @@ class Config(BaseSettings):
         ),
     )
 
-    alert_hook: HttpUrl | None = Field(
+    alert_hook: SecretStr | None = Field(
         None,
-        title="Slack webhook URL used for sending alerts",
-        description=(
-            "An https URL, which should be considered secret. If not set or"
-            " set to `None`, this feature will be disabled."
-        ),
+        title="Slack alert webhook URL",
+        description="Slack incoming webhook to which to send alerts",
         examples=["https://slack.example.com/ADFAW1452DAF41/"],
         validation_alias=AliasChoices("MOBU_ALERT_HOOK", "alertHook"),
     )

--- a/src/mobu/factory.py
+++ b/src/mobu/factory.py
@@ -90,7 +90,7 @@ class Factory:
         """
         if self._config.slack_alerts and self._config.alert_hook:
             return SlackWebhookClient(
-                str(self._config.alert_hook), "Mobu", self._logger
+                self._config.alert_hook, "Mobu", self._logger
             )
         return None
 

--- a/src/mobu/services/monkey.py
+++ b/src/mobu/services/monkey.py
@@ -151,7 +151,7 @@ class Monkey:
         self._slack = None
         if self._config.slack_alerts and self._config.alert_hook:
             self._slack = SlackWebhookClient(
-                str(self._config.alert_hook), "Mobu", self._global_logger
+                self._config.alert_hook, "Mobu", self._global_logger
             )
 
     async def alert(self, exc: Exception) -> None:


### PR DESCRIPTION
The Slack alert webhook URL is an incoming webhook that allows direct Slack posting as mobu, so it is a secret and should be treated as such. Change its type in the mobu configuration and pass it directly to the Safir Slack library, since those classes support `SecretStr` as an input type.