### PR TITLE
DM-48977: Add docs-linkcheck target and fix issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,32 +54,6 @@ jobs:
           tox-envs: "py,coverage-report,typing"
           tox-requirements: requirements/tox.txt
 
-  build:
-    runs-on: ubuntu-latest
-    needs: [lint, test]
-    timeout-minutes: 10
-
-    # Only do Docker builds of tagged releases and pull requests from ticket
-    # branches. This will still trigger on pull requests from untrusted
-    # repositories whose branch names match our tickets/* branch convention,
-    # but in this case the build will fail with an error since the secret
-    # won't be set.
-    if: >
-      github.event_name != 'merge_group'
-      && (startsWith(github.ref, 'refs/tags/')
-          || startsWith(github.head_ref, 'tickets/'))
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: lsst-sqre/build-and-push-to-ghcr@v1
-        id: build
-        with:
-          image: ${{ github.repository }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
   docs:
     runs-on: ubuntu-latest
 
@@ -101,7 +75,10 @@ jobs:
 
       - name: Install graphviz
         if: steps.filter.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
-        run: sudo apt-get install graphviz
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
+        shell: bash
 
       - name: Build docs
         if: steps.filter.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
@@ -128,3 +105,62 @@ jobs:
           || (github.event_name == 'merge_group' && steps.filter.outputs.docs == 'true')
           || (github.event_name == 'workflow_dispatch')
           || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'tickets/') && steps.filter.outputs.docsSpecific == 'true')
+
+  linkcheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Filter paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - "docs/**"
+              - "src/mobu/**"
+            docsSpecific:
+              - "docs/**"
+
+      - name: Install extra packages
+        if: steps.filter.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y graphviz
+        shell: bash
+
+      - name: Check links
+        if: steps.filter.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          tox-envs: docs-linkcheck
+          tox-requirements: "requirements/tox.txt"
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    timeout-minutes: 10
+
+    # Only do Docker builds of tagged releases and pull requests from ticket
+    # branches. This will still trigger on pull requests from untrusted
+    # repositories whose branch names match our tickets/* branch convention,
+    # but in this case the build will fail with an error since the secret
+    # won't be set.
+    if: >
+      github.event_name != 'merge_group'
+      && (startsWith(github.ref, 'refs/tags/')
+          || startsWith(github.head_ref, 'tickets/'))
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: lsst-sqre/build-and-push-to-ghcr@v1
+        id: build
+        with:
+          image: ${{ github.repository }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,7 +226,7 @@ Find changes for the upcoming release in the project's [changelog.d](https://git
 
 - The default `error_idle_time` for Nublado-based business is back to 60 seconds instead of 10 minutes. The problem the longer timeout was working around should be fixed in the new Nublado lab controller.
 - Nublado-based notebooks now request the `JUPYTER_IMAGE_SPEC` environment variable instead of `JUPYTER_IMAGE` to get the running image for error reporting purposes. This is now the preferred environment variable and `JUPYTER_IMAGE` is deprecated.
-- mobu now uses the [Ruff](https://beta.ruff.rs/docs/) linter instead of flake8, isort, and pydocstyle.
+- mobu now uses the [Ruff](https://docs.astral.sh/ruff/) linter instead of flake8, isort, and pydocstyle.
 
 ## 5.0.0 (2023-03-22)
 

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 help:
 	@echo "Make targets for mobu"
 	@echo "make init - Set up dev environment"
+	@echo "make linkcheck - Check for broken links in documentation"
 	@echo "make run - Run development instance of server"
 	@echo "make update - Update pinned dependencies and run make init"
 	@echo "make update-deps - Update pinned dependencies"
@@ -14,6 +15,16 @@ init:
 	uv pip install -r requirements/main.txt -r requirements/dev.txt
 	rm -rf .tox
 	pre-commit install
+
+# This is defined as a Makefile target instead of only a tox command because
+# if the command fails we want to cat output.txt, which contains the
+# actually useful linkcheck output. tox unfortunately doesn't support this
+# level of shell trickery after failed commands.
+.PHONY: linkcheck
+linkcheck:
+	sphinx-build -W --keep-going -n -T -b linkcheck docs	\
+	    docs/_build/linkcheck				\
+	    || (cat docs/_build/linkcheck/output.txt; exit 1)
 
 .PHONY: run
 run:

--- a/docs/development/sentry.rst
+++ b/docs/development/sentry.rst
@@ -5,7 +5,7 @@ Sentry Integration
 Mobu integrates with Sentry differently than most other apps, because the unit of work isn't a request like in a web app, it's an iteration (or part of an iteration) of a business.
 As a result, some things are different about this Sentry integration.
 
-Scopes and Transactions
+Scopes and transactions
 =======================
 
 `Isolation scopes <https://docs.sentry.io/platforms/python/enriching-events/scopes/>`_ and `transactions <https://docs.sentry.io/platforms/python/tracing/instrumentation/custom-instrumentation/#add-a-transaction>`_ are created manually.
@@ -23,10 +23,10 @@ Fingerprints
 We add tags to the fingerprint of every event sent to Sentry to force the creation of separate issues where only one issue would be created by default.
 For example, we add notebook and cell ids to the fingerprint to force different issues (and thus different notifications) for errors from different notebooks and cells.
 
-Traces Sampling
+Traces sampling
 ===============
 
 The ``sentry_traces_sample_config``/``sentryTracesSampleConfig`` option can be set to:
 
-* A float, in which case it will be passed directly to `traces_sample_rate <https://docs.sentry.io/platforms/python/configuration/options/#traces-sample-rate>`_ when initializing Sentry, and only send that percentage of transactions to Sentry
+* A float, in which case it will be passed directly to `traces_sample_rate <https://docs.sentry.io/platforms/python/configuration/options/#traces_sample_rate>`_ when initializing Sentry, and only send that percentage of transactions to Sentry
 * The string "errors", in which case transactions will be sent to Sentry only if errors occurred during them

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -10,3 +10,10 @@ openapi_path = "_static/openapi.json"
 
 [project.openapi.generator]
 function = "mobu.main:create_openapi"
+
+[sphinx.linkcheck]
+ignore = [
+    # Authenticated
+    '^https://data\.lsst\.cloud/mobu',
+    '^https://github\.com/organizations/lsst-sqre/settings',
+]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Mobu
 ####
 
 mobu (short for "monkey business") is a continous integration testing framework for the `Rubin Science Platform <https://phalanx.lsst.io/>`__ .
-It attempts to simulate user interactions with Science Platform services continuously, recording successes and failures and reporting failures to `Sentry <https://sentry.io>`_.
+It attempts to simulate user interactions with Science Platform services continuously, recording successes and failures and reporting failures to `Sentry <https://sentry.io/welcome/>`_.
 It runs some number of "monkeys" that simulate a random user of the Science Platform.
 Those monkeys are organized into "flocks" that share a single configuration across all of the monkeys.
 It can be used for both monitoring and synthetic load testing.

--- a/docs/user_guide/flocks.rst
+++ b/docs/user_guide/flocks.rst
@@ -4,9 +4,7 @@ Managing mobu flocks
 
 Mobu calls each test runner a "monkey" and organizes them into groups called "flocks."
 You can get a list of flocks from the mobu API.
-For example, on the IDF production deployment, go to:
-
-`https://data.lsst.cloud/mobu/summary <https://data.lsst.cloud/mobu/summary>`_
+For example, on the IDF production deployment, go to `https://data.lsst.cloud/mobu/summary <https://data.lsst.cloud/mobu/summary>`_
 
 Flocks can be also manipulated through the API.
 For example, to stop a noisy flock running on ``data.lsst.cloud`` while troubleshooting is in progress, first obtain a token with ``exec:admin`` scope from the authentication service, and then:

--- a/tox.ini
+++ b/tox.ini
@@ -20,23 +20,26 @@ commands = coverage report
 
 [testenv:docs]
 description = Build documentation (HTML) with Sphinx.
-setenv =
-    MOBU_ENVIRONMENT_URL = https://test.example.com
-    MOBU_GITHUB_REFRESH_APP_ENABLED = true
-    MOBU_GITHUB_CI_APP_ENABLED = true
 allowlist_externals =
     rm
 commands =
     rm -rf docs/internals/api/
+    # https://github.com/sphinx-contrib/redoc/issues/48
+    rm -f docs/_build/html/_static/redoc.js
     sphinx-build -W --keep-going -n -T -b html -d {envtmpdir}/doctrees docs docs/_build/html
 
-[testenv:typing]
-description = Run mypy.
+[testenv:docs-linkcheck]
+description = Check links in the documentation.
+allowlist_externals =
+    make
+    rm
 commands =
-    mypy src/mobu tests
+    # https://github.com/sphinx-contrib/redoc/issues/48
+    rm -f docs/_build/linkcheck/_static/redoc.js
+    make linkcheck
 
 [testenv:lint]
-description = Lint codebase by running pre-commit (Black, isort, Flake8).
+description = Lint codebase by running pre-commit (Ruff).
 skip_install = true
 deps =
     pre-commit
@@ -46,3 +49,8 @@ commands = pre-commit run --all-files
 description = Run the development server with auto-reload for code changes.
 usedevelop = true
 commands = uvicorn mobu.main:create_app --reload
+
+[testenv:typing]
+description = Run mypy.
+commands =
+    mypy src/mobu tests


### PR DESCRIPTION
Add a `docs-linkcheck` tox environment to support the periodic CI run, and fix the link problems that it uncovered. Add a linkcheck action in GitHub Actions, which won't block merging but which will warn if link checking failed.