### PR TITLE
DM-49320: Refactor notebook businesses

### DIFF
--- a/changelog.d/20250306_142638_danfuchs_HEAD.md
+++ b/changelog.d/20250306_142638_danfuchs_HEAD.md
@@ -1,0 +1,4 @@
+### Backwards-incompatible changes
+
+- The `NotebookRunner` buisiness has been split into two different businesses: `NotebookRunnerCounting` and `NotebookRunnerList`. The difference is that `NotebookRunnerCounting` takes the `max_executions` option that refreshes the lab after that number of notebook executions, and `NotebookRunnerList` takes the `notebooks_to_run` option, which runs all of the notebooks in that list before refreshing. Currently, `NotebookRunnerList` is only used by the GitHub CI functionality.
+  - Any references to `NotebookRunner` in any flock config need to be changed to to one of these new businesses, almost certainly `NotebookRunnerCounting`.

--- a/docs/development/idfdev.rst
+++ b/docs/development/idfdev.rst
@@ -47,7 +47,7 @@ You can run mobu locally while having all of the actual business run against ser
               scopes:
                 - "exec:notebook"
               business:
-                type: "NotebookRunner"
+                type: "NotebookRunnerCounting"
                 options:
                   repo_url: "https://github.com/lsst-sqre/dfuchs-test-mobu.git"
                   repo_ref: "dfuchs-test-pr"
@@ -60,7 +60,7 @@ You can run mobu locally while having all of the actual business run against ser
               scopes:
                 - "exec:notebook"
               business:
-                type: "NotebookRunner"
+                type: "NotebookRunnerCounting"
                 options:
                   repo_url: "https://github.com/lsst-sqre/dfuchs-test-mobu.git"
                   repo_ref: "main"

--- a/docs/user-guide/flocks.rst
+++ b/docs/user-guide/flocks.rst
@@ -114,7 +114,7 @@ Here is a more complex example that runs a set of notebooks as a test:
          - "read:image"
          - "read:tap"
        business:
-         type: "NotebookRunner"
+         type: "NotebookRunnerCounting"
          options:
            repo_url: "https://github.com/lsst-sqre/system-test.git"
            repo_ref: "prod"
@@ -148,7 +148,7 @@ Here is a different example that runs multiple monkeys in a flock:
          - "read:image"
          - "read:tap"
        business:
-         type: "NotebookRunner"
+         type: "NotebookRunnerCounting"
          options:
            repo_url: "https://github.com/lsst-sqre/system-test.git"
            repo_ref: "prod"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,8 @@ extend = "ruff-shared.toml"
     "ASYNC110", # TAP code could be rewritten to poll state differently
 ]
 "src/mobu/services/monkey.py" = [
+    "C901",   # we have a lot of business types, thus big conditionals
+    "PLR0912",   # we have a lot of business types, thus big conditionals
     "SIM115",   # we do want a NamedTemporaryFile not in a context manager
 ]
 "tests/data/**/*.ipynb" = [

--- a/src/mobu/models/business/business_config_type.py
+++ b/src/mobu/models/business/business_config_type.py
@@ -4,7 +4,8 @@ from typing import TypeAlias
 
 from .empty import EmptyLoopConfig
 from .gitlfs import GitLFSConfig
-from .notebookrunner import NotebookRunnerConfig
+from .notebookrunnercounting import NotebookRunnerCountingConfig
+from .notebookrunnerlist import NotebookRunnerListConfig
 from .nubladopythonloop import NubladoPythonLoopConfig
 from .siaquerysetrunner import SIAQuerySetRunnerConfig
 from .tapqueryrunner import TAPQueryRunnerConfig
@@ -13,7 +14,8 @@ from .tapquerysetrunner import TAPQuerySetRunnerConfig
 BusinessConfigType: TypeAlias = (
     TAPQueryRunnerConfig
     | GitLFSConfig
-    | NotebookRunnerConfig
+    | NotebookRunnerCountingConfig
+    | NotebookRunnerListConfig
     | NubladoPythonLoopConfig
     | TAPQuerySetRunnerConfig
     | SIAQuerySetRunnerConfig

--- a/src/mobu/models/business/notebookrunner.py
+++ b/src/mobu/models/business/notebookrunner.py
@@ -1,26 +1,24 @@
-"""Models for the NotebookRunner monkey business."""
-
-from __future__ import annotations
+"""Shared models for different notebook runners."""
 
 from pathlib import Path
-from typing import Literal
 
 from pydantic import BaseModel, Field
 
 from ...constants import NOTEBOOK_REPO_BRANCH, NOTEBOOK_REPO_URL
-from .base import BusinessConfig
-from .nublado import NubladoBusinessData, NubladoBusinessOptions
+from ...models.business.nublado import (
+    NubladoBusinessData,
+    NubladoBusinessOptions,
+)
 
 __all__ = [
-    "ListNotebookRunnerOptions",
     "NotebookFilterResults",
-    "NotebookRunnerConfig",
+    "NotebookMetadata",
     "NotebookRunnerData",
     "NotebookRunnerOptions",
 ]
 
 
-class BaseNotebookRunnerOptions(NubladoBusinessOptions):
+class NotebookRunnerOptions(NubladoBusinessOptions):
     """Options for all types NotebookRunner monkey business."""
 
     repo_ref: str = Field(
@@ -45,49 +43,6 @@ class BaseNotebookRunnerOptions(NubladoBusinessOptions):
             " Only used by the NotebookRunner."
         ),
         examples=["some-dir", "some-dir/some-other-dir"],
-    )
-
-
-class NotebookRunnerOptions(BaseNotebookRunnerOptions):
-    """Options to specify a fixed number of notebooks to run per session."""
-
-    max_executions: int = Field(
-        25,
-        title="How much to execute in a given lab and session",
-        description=(
-            " NotebookRunner goes through the directory of notebooks"
-            " one-by-one, running the entirety of each one and starting"
-            " again at the beginning of the list when it runs out, until"
-            " it has executed a total of `max_executions` notebooks. It then"
-            " closes the session (and optionally deletes and recreates the"
-            " lab, controlled by `delete_lab`), and then picks up where it"
-            " left off."
-        ),
-        examples=[25],
-        ge=1,
-    )
-
-
-class ListNotebookRunnerOptions(BaseNotebookRunnerOptions):
-    """Options to specify a list of notebooks to run per session."""
-
-    notebooks_to_run: list[Path] = Field(
-        [],
-        title="Specific notebooks to run",
-        description=("Only these specific notebooks will be executed."),
-    )
-
-
-class NotebookRunnerConfig(BusinessConfig):
-    """Configuration specialization for NotebookRunner."""
-
-    type: Literal["NotebookRunner"] = Field(
-        ..., title="Type of business to run"
-    )
-
-    options: NotebookRunnerOptions | ListNotebookRunnerOptions = Field(
-        default_factory=NotebookRunnerOptions,
-        title="Options for the monkey business",
     )
 
 

--- a/src/mobu/models/business/notebookrunnercounting.py
+++ b/src/mobu/models/business/notebookrunnercounting.py
@@ -1,0 +1,48 @@
+"""Models for the NotebookRunnerCounting monkey business."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from .base import BusinessConfig
+from .notebookrunner import NotebookRunnerOptions
+
+__all__ = [
+    "NotebookRunnerCountingConfig",
+    "NotebookRunnerCountingOptions",
+]
+
+
+class NotebookRunnerCountingOptions(NotebookRunnerOptions):
+    """Options to specify a fixed number of notebooks to run per session."""
+
+    max_executions: int = Field(
+        25,
+        title="How much to execute in a given lab and session",
+        description=(
+            " NotebookRunnerCounting goes through the directory of notebooks"
+            " one-by-one, running the entirety of each one and starting"
+            " again at the beginning of the list when it runs out, until"
+            " it has executed a total of `max_executions` notebooks. It then"
+            " closes the session (and optionally deletes and recreates the"
+            " lab, controlled by `delete_lab`), and then picks up where it"
+            " left off."
+        ),
+        examples=[25],
+        ge=1,
+    )
+
+
+class NotebookRunnerCountingConfig(BusinessConfig):
+    """Configuration specialization for NotebookRunnerCounting."""
+
+    type: Literal["NotebookRunnerCounting"] = Field(
+        ..., title="Type of business to run"
+    )
+
+    options: NotebookRunnerCountingOptions = Field(
+        default_factory=NotebookRunnerCountingOptions,
+        title="Options for the monkey business",
+    )

--- a/src/mobu/models/business/notebookrunnerlist.py
+++ b/src/mobu/models/business/notebookrunnerlist.py
@@ -1,0 +1,37 @@
+"""Models for the NotebookRunnerList monkey business."""
+
+from pathlib import Path
+from typing import Literal
+
+from pydantic import Field
+
+from ...models.business.base import BusinessConfig
+from .notebookrunner import NotebookRunnerOptions
+
+__all__ = [
+    "NotebookRunnerListConfig",
+    "NotebookRunnerListOptions",
+]
+
+
+class NotebookRunnerListOptions(NotebookRunnerOptions):
+    """Specify a list of notebooks to run in a single lab session."""
+
+    notebooks_to_run: list[Path] = Field(
+        [],
+        title="Specific notebooks to run",
+        description=("Only these specific notebooks will be executed."),
+    )
+
+
+class NotebookRunnerListConfig(BusinessConfig):
+    """Configuration specialization for NotebookRunnerList."""
+
+    type: Literal["NotebookRunnerList"] = Field(
+        ..., title="Type of business to run"
+    )
+
+    options: NotebookRunnerListOptions = Field(
+        default_factory=NotebookRunnerListOptions,
+        title="Options for the monkey business",
+    )

--- a/src/mobu/models/flock.py
+++ b/src/mobu/models/flock.py
@@ -100,7 +100,7 @@ class FlockSummary(BaseModel):
     business: str = Field(
         ...,
         title="Name of the business the flock is running",
-        examples=["NotebookRunner"],
+        examples=["NotebookRunnerCounting"],
     )
 
     start_time: datetime | None = Field(

--- a/src/mobu/services/business/notebookrunnercounting.py
+++ b/src/mobu/services/business/notebookrunnercounting.py
@@ -1,0 +1,62 @@
+"""Execute notebooks in batches of a fixed number per JuypterLab session."""
+
+from typing import override
+
+from structlog.stdlib import BoundLogger
+
+from ...events import Events
+from ...models.business.notebookrunnercounting import (
+    NotebookRunnerCountingOptions,
+)
+from ...models.user import AuthenticatedUser
+from ...services.repo import RepoManager
+from .notebookrunner import ExecutionIteration, NotebookRunner
+
+__all__ = ["NotebookRunnerCounting"]
+
+
+class NotebookRunnerCounting(NotebookRunner):
+    """A notebook runner that refreshes JupyterLab sessions (and optionally
+    deletes the labs) after a configurable number of notebook executions.
+
+    Parameters
+    ----------
+    options
+        Configuration options for the business.
+    user
+        User with their authentication token to use to run the business.
+    events
+        Event publishers.
+    logger
+        Logger to use to report the results of business.
+    flock
+        Flock that is running this business, if it is running in a flock.
+    """
+
+    def __init__(
+        self,
+        *,
+        options: NotebookRunnerCountingOptions,
+        user: AuthenticatedUser,
+        repo_manager: RepoManager,
+        events: Events,
+        logger: BoundLogger,
+        flock: str | None,
+    ) -> None:
+        super().__init__(
+            options=options,
+            user=user,
+            repo_manager=repo_manager,
+            events=events,
+            logger=logger,
+            flock=flock,
+        )
+        self._max_executions = options.max_executions
+
+    @override
+    def execution_iterator(self) -> ExecutionIteration:
+        """Return an iterator counts up to a fixed amount."""
+        return ExecutionIteration(
+            iterator=iter(range(self._max_executions)),
+            size=self._max_executions,
+        )

--- a/src/mobu/services/business/notebookrunnerlist.py
+++ b/src/mobu/services/business/notebookrunnerlist.py
@@ -1,0 +1,61 @@
+"""Execute a list of notebooks in a single JupyterLab session."""
+
+from typing import override
+
+from structlog.stdlib import BoundLogger
+
+from ...events import Events
+from ...models.business.notebookrunnerlist import NotebookRunnerListOptions
+from ...models.user import AuthenticatedUser
+from ...services.repo import RepoManager
+from .notebookrunner import ExecutionIteration, NotebookRunner
+
+__all__ = ["NotebookRunnerList"]
+
+
+class NotebookRunnerList(NotebookRunner):
+    """A notebook runner that refreshes JupyterLab sessions (and optionally
+    deletes the labs) after a list of notebooks has been executed.
+
+    Parameters
+    ----------
+    options
+        Configuration options for the business.
+    user
+        User with their authentication token to use to run the business.
+    events
+        Event publishers.
+    logger
+        Logger to use to report the results of business.
+    flock
+        Flock that is running this business, if it is running in a flock.
+    """
+
+    def __init__(
+        self,
+        *,
+        options: NotebookRunnerListOptions,
+        user: AuthenticatedUser,
+        repo_manager: RepoManager,
+        events: Events,
+        logger: BoundLogger,
+        flock: str | None,
+    ) -> None:
+        super().__init__(
+            options=options,
+            user=user,
+            repo_manager=repo_manager,
+            events=events,
+            logger=logger,
+            flock=flock,
+        )
+        self._notebooks_to_run = options.notebooks_to_run
+
+    @override
+    def execution_iterator(self) -> ExecutionIteration:
+        """Return an iterator counts the number of specified notebooks."""
+        size = len(self._notebooks.runnable)
+        return ExecutionIteration(
+            iterator=iter(range(size)),
+            size=size,
+        )

--- a/src/mobu/services/flock.py
+++ b/src/mobu/services/flock.py
@@ -13,9 +13,9 @@ from structlog.stdlib import BoundLogger
 
 from ..events import Events
 from ..exceptions import MonkeyNotFoundError
-from ..models.business.notebookrunner import (
-    NotebookRunnerConfig,
-    NotebookRunnerOptions,
+from ..models.business.notebookrunnercounting import (
+    NotebookRunnerCountingConfig,
+    NotebookRunnerCountingOptions,
 )
 from ..models.flock import FlockConfig, FlockData, FlockSummary
 from ..models.user import AuthenticatedUser, User, UserSpec
@@ -183,8 +183,8 @@ class Flock:
     def uses_repo(self, repo_url: str, repo_ref: str) -> bool:
         match self._config:
             case FlockConfig(
-                business=NotebookRunnerConfig(
-                    options=NotebookRunnerOptions(
+                business=NotebookRunnerCountingConfig(
+                    options=NotebookRunnerCountingOptions(
                         repo_url=url,
                         repo_ref=branch,
                     )

--- a/src/mobu/services/github_ci/ci_notebook_job.py
+++ b/src/mobu/services/github_ci/ci_notebook_job.py
@@ -5,11 +5,12 @@ from pathlib import Path
 from httpx import AsyncClient
 from structlog.stdlib import BoundLogger
 
-from ...events import Events
-from ...models.business.notebookrunner import (
-    ListNotebookRunnerOptions,
-    NotebookRunnerConfig,
+from mobu.models.business.notebookrunnerlist import (
+    NotebookRunnerListConfig,
+    NotebookRunnerListOptions,
 )
+
+from ...events import Events
 from ...models.ci_manager import CiJobSummary
 from ...models.solitary import SolitaryConfig
 from ...models.user import User
@@ -90,9 +91,9 @@ class CiNotebookJob:
         solitary_config = SolitaryConfig(
             user=user,
             scopes=[str(scope) for scope in scopes],
-            business=NotebookRunnerConfig(
-                type="NotebookRunner",
-                options=ListNotebookRunnerOptions(
+            business=NotebookRunnerListConfig(
+                type="NotebookRunnerList",
+                options=NotebookRunnerListOptions(
                     repo_ref=self._github.ref,
                     repo_url=f"https://github.com/{self._github.repo_owner}/{self._github.repo_name}.git",
                     notebooks_to_run=self._notebooks,

--- a/src/mobu/services/monkey.py
+++ b/src/mobu/services/monkey.py
@@ -19,18 +19,22 @@ from ..events import Events
 from ..models.business.base import BusinessConfig
 from ..models.business.empty import EmptyLoopConfig
 from ..models.business.gitlfs import GitLFSConfig
-from ..models.business.notebookrunner import NotebookRunnerConfig
+from ..models.business.notebookrunnercounting import (
+    NotebookRunnerCountingConfig,
+)
+from ..models.business.notebookrunnerlist import NotebookRunnerListConfig
 from ..models.business.nubladopythonloop import NubladoPythonLoopConfig
 from ..models.business.siaquerysetrunner import SIAQuerySetRunnerConfig
 from ..models.business.tapqueryrunner import TAPQueryRunnerConfig
 from ..models.business.tapquerysetrunner import TAPQuerySetRunnerConfig
 from ..models.monkey import MonkeyData, MonkeyState
 from ..models.user import AuthenticatedUser
+from ..services.business.notebookrunnercounting import NotebookRunnerCounting
+from ..services.business.notebookrunnerlist import NotebookRunnerList
 from ..services.repo import RepoManager
 from .business.base import Business
 from .business.empty import EmptyLoop
 from .business.gitlfs import GitLFSBusiness
-from .business.notebookrunner import NotebookRunner
 from .business.nubladopythonloop import NubladoPythonLoop
 from .business.siaquerysetrunner import SIAQuerySetRunner
 from .business.tapqueryrunner import TAPQueryRunner
@@ -127,8 +131,17 @@ class Monkey:
                 logger=self._logger,
                 flock=self._flock,
             )
-        elif isinstance(business_config, NotebookRunnerConfig):
-            self.business = NotebookRunner(
+        elif isinstance(business_config, NotebookRunnerCountingConfig):
+            self.business = NotebookRunnerCounting(
+                options=business_config.options,
+                user=user,
+                events=self._events,
+                repo_manager=self._repo_manager,
+                logger=self._logger,
+                flock=self._flock,
+            )
+        elif isinstance(business_config, NotebookRunnerListConfig):
+            self.business = NotebookRunnerList(
                 options=business_config.options,
                 user=user,
                 events=self._events,

--- a/src/mobu/services/notebook_finder.py
+++ b/src/mobu/services/notebook_finder.py
@@ -1,0 +1,151 @@
+"""Helpers to pick which notebooks in a repo to execute."""
+
+import json
+from pathlib import Path
+
+from structlog.stdlib import BoundLogger
+
+from mobu.exceptions import NotebookRepositoryError
+
+from ..models.business.notebookrunner import (
+    NotebookFilterResults,
+    NotebookMetadata,
+)
+
+
+class NotebookFinder:
+    """A helper to select which notebooks to execute based on config.
+
+    This config can come from many places, like flock config, or an in-repo
+    config file.
+
+    Parameters
+    ----------
+    repo_path
+        The local path on disk of a cloned repository of notebooks.
+    exclude_paths
+        A set of paths in which any descendant notebooks will not be executed.
+    notebooks_to_run
+        A list of notebooks that will be considered for execution. If this is
+        None, then all notebooks in the repo will be considered.
+    available_services
+        A list of Phalanx services that are available in the environment.
+    logger
+        A structlog logger
+    """
+
+    def __init__(
+        self,
+        *,
+        repo_path: Path,
+        exclude_paths: set[Path],
+        notebooks_to_run: list[Path] | None,
+        available_services: set[str],
+        logger: BoundLogger,
+    ) -> None:
+        self._repo_path = repo_path
+        self._exclude_paths = exclude_paths
+        self._notebooks_to_run = notebooks_to_run
+        self._available_services = available_services
+        self._logger = logger.bind(
+            repo_path=self._repo_path,
+            exclude_paths=self._exclude_paths,
+            notebooks_to_run=self._notebooks_to_run,
+        )
+
+    def find(self) -> NotebookFilterResults:
+        """Return a list of notebooks to execute.
+
+        If a list of starting notebooks was provided at construction, then the
+        starting list of candiates is those notebooks. Otherwise, all notebooks
+        in the repo will be considered.
+
+        Notebooks in the starting list will be excluded if:
+        * They are descendants of specifically excluded directories
+        * They list required services in their metadata and any of those
+          services are not provided in the current environment
+        """
+        all_notebooks = set(self._repo_path.glob("**/*.ipynb"))
+        if not all_notebooks:
+            msg = "No notebooks found in {self._repo_dir}"
+            raise NotebookRepositoryError(msg)
+
+        results = NotebookFilterResults(all=all_notebooks)
+        results.excluded_by_dir = {
+            n for n in results.all if self._excluded_by_dir(n)
+        }
+        results.excluded_by_service = {
+            n for n in results.all if self._excluded_by_service(n)
+        }
+
+        results.excluded_by_requested = self._excluded_by_requested(
+            results.all
+        )
+
+        results.runnable = (
+            results.all
+            - results.excluded_by_service
+            - results.excluded_by_dir
+            - results.excluded_by_requested
+        )
+        if bool(results.runnable):
+            self._logger.info(
+                "Found notebooks to run",
+                filter_results=results.model_dump(),
+            )
+        else:
+            self._logger.warning(
+                "No notebooks to run after filtering!",
+                filter_results=results.model_dump(),
+            )
+
+        return results
+
+    def _excluded_by_dir(self, notebook: Path) -> bool:
+        # A notebook is excluded if any of its parent directories are excluded
+        return bool(set(notebook.parents) & self._exclude_paths)
+
+    def _excluded_by_service(self, notebook: Path) -> bool:
+        """Return True if a notebook declares required services and they are
+        available.
+        """
+        metadata = self._read_notebook_metadata(notebook)
+        missing_services = (
+            metadata.required_services - self._available_services
+        )
+        if missing_services:
+            msg = "Environment does not provide required services for notebook"
+            self._logger.info(
+                msg,
+                notebook=notebook,
+                required_services=metadata.required_services,
+                missing_services=missing_services,
+            )
+            return True
+        return False
+
+    def _excluded_by_requested(self, all: set[Path]) -> set[Path]:
+        if not self._notebooks_to_run:
+            return set()
+
+        requested = {
+            self._repo_path / notebook for notebook in self._notebooks_to_run
+        }
+        not_found = requested - all
+        if not_found:
+            msg = (
+                "Requested notebooks do not exist in"
+                f" {self._repo_path}: {not_found}"
+            )
+            raise NotebookRepositoryError(msg)
+        return all - requested
+
+    def _read_notebook_metadata(self, notebook: Path) -> NotebookMetadata:
+        try:
+            notebook_text = notebook.read_text()
+            notebook_json = json.loads(notebook_text)
+            metadata = notebook_json["metadata"].get("mobu", {})
+            return NotebookMetadata.model_validate(metadata)
+        except Exception as e:
+            msg = f"Invalid notebook metadata {notebook.name}: {e!s}"
+            raise NotebookRepositoryError(msg) from e

--- a/tests/business/notebookrunnerlist_test.py
+++ b/tests/business/notebookrunnerlist_test.py
@@ -1,0 +1,129 @@
+"""Tests for the NotebookRunnerList business."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from unittest.mock import ANY
+
+import pytest
+import respx
+from httpx import AsyncClient
+
+from mobu.storage.git import Git
+
+from ..support.constants import TEST_DATA_DIR
+from ..support.gafaelfawr import mock_gafaelfawr
+from ..support.util import wait_for_business
+
+
+async def setup_git_repo(repo_path: Path) -> str:
+    """Initialize and populate a git repo at `repo_path`.
+
+    Returns
+    -------
+    str
+        Commit hash of the cloned repo
+    """
+    git = Git(repo=repo_path)
+    await git.init("--initial-branch=main")
+    await git.config("user.email", "gituser@example.com")
+    await git.config("user.name", "Git User")
+    for path in repo_path.iterdir():
+        if not path.name.startswith("."):
+            await git.add(str(path))
+    await git.commit("-m", "Initial commit")
+    return await git.repo_hash()
+
+
+@pytest.mark.asyncio
+async def test_run_all_notebooks(
+    client: AsyncClient, respx_mock: respx.Router, tmp_path: Path
+) -> None:
+    mock_gafaelfawr(respx_mock)
+    cwd = Path.cwd()
+
+    # Set up a notebook repository.
+    source_path = TEST_DATA_DIR / "notebooks_services"
+    repo_path = tmp_path / "notebooks"
+
+    shutil.copytree(str(source_path), str(repo_path))
+
+    # Exclude some notebooks
+    (repo_path / "mobu.yaml").write_text('exclude_dirs: ["some-dir"]')
+
+    # Set up git repo
+    await setup_git_repo(repo_path)
+
+    # Start a monkey. We have to do this in a try/finally block since the
+    # runner will change working directories, which because working
+    # directories are process-global may mess up future tests.
+    try:
+        # Note `max_executions` is not declared here, `notebooks_to_run` is
+        # declared instead.
+        r = await client.put(
+            "/mobu/flocks",
+            json={
+                "name": "test",
+                "count": 1,
+                "user_spec": {"username_prefix": "bot-mobu-testuser"},
+                "scopes": ["exec:notebook"],
+                "business": {
+                    "type": "NotebookRunnerList",
+                    "options": {
+                        "spawn_settle_time": 0,
+                        "execution_idle_time": 0,
+                        "repo_url": str(repo_path),
+                        "repo_ref": "main",
+                        "notebooks_to_run": [
+                            "test-notebook-has-services.ipynb",
+                            # This shouldn't run because services are missing
+                            "test-notebook-missing-service.ipynb",
+                            # This shouldn't run because the dir is excluded
+                            "some-dir/test-other-notebook-has-services.ipynb",
+                        ],
+                        "working_directory": str(repo_path),
+                    },
+                },
+            },
+        )
+        assert r.status_code == 201
+
+        # Wait until we've finished one loop and check the results.
+        data = await wait_for_business(client, "bot-mobu-testuser1")
+        assert data == {
+            "name": "bot-mobu-testuser1",
+            "business": {
+                "failure_count": 0,
+                "name": "NotebookRunnerList",
+                "notebook": "test-notebook-has-services.ipynb",
+                "refreshing": False,
+                "success_count": 1,
+            },
+            "state": "RUNNING",
+            "user": {
+                "scopes": ["exec:notebook"],
+                "token": ANY,
+                "username": "bot-mobu-testuser1",
+            },
+        }
+    finally:
+        os.chdir(cwd)
+
+    # Get the log and check the cell output.
+    r = await client.get("/mobu/flocks/test/monkeys/bot-mobu-testuser1/log")
+    assert r.status_code == 200
+
+    # Notebooks with all services available
+    assert "Required services are available" in r.text
+    assert "Final test" in r.text
+
+    # Should have been excluded by dir
+    assert "Required services are available - some-dir" not in r.text
+
+    # Notebook with missing services
+    assert "Required services are NOT available" not in r.text
+
+    # Make sure mobu ran all of the notebooks it thinks it should have
+    assert "Done with this cycle of notebooks" in r.text

--- a/tests/handlers/github_refresh_app_test.py
+++ b/tests/handlers/github_refresh_app_test.py
@@ -107,7 +107,7 @@ async def test_handle_webhook(
             "user_spec": {"username_prefix": "bot-mobu-testuser-notebook"},
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "NotebookRunner",
+                "type": "NotebookRunnerCounting",
                 "options": {
                     "repo_url": "https://github.com/lsst-sqre/some-repo.git",
                     "repo_ref": "main",
@@ -122,7 +122,7 @@ async def test_handle_webhook(
             },
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "NotebookRunner",
+                "type": "NotebookRunnerCounting",
                 "options": {
                     "repo_url": "https://github.com/lsst-sqre/some-repo.git",
                     "repo_ref": "some-branch",
@@ -137,7 +137,7 @@ async def test_handle_webhook(
             },
             "scopes": ["exec:notebook"],
             "business": {
-                "type": "NotebookRunner",
+                "type": "NotebookRunnerCounting",
                 "options": {
                     "repo_url": "https://github.com/lsst-sqre/some-other-repo.git",
                     "repo_ref": "main",

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -22,7 +22,7 @@ async def test_post_status(
         mock.return_value = [
             FlockSummary(
                 name="notebook",
-                business="NotebookRunner",
+                business="NotebookRunnerCounting",
                 start_time=datetime(2021, 8, 20, 17, 3, tzinfo=UTC),
                 monkey_count=5,
                 success_count=487,


### PR DESCRIPTION
The `NotebookRunner` business currently can accept two kinds of options, one which specifies `max_executions` and runs a constant number of notebooks before refreshing the lab, and one which specifies `notebooks_to_run`, which takes a list of notebooks and runs them all before refreshing.

[To keep consistency with the overall Mobu design](https://github.com/lsst-sqre/mobu/pull/363#discussion_r1688699419), there should be a 1:1 mapping between businesses and business option types. We're about to add a third variation on behavior (don't ever refresh a lab), so by the rule of three, let's clean up this debt and do this refactoring now.

Another piece of debt clean up done here is to split the notebook filtering logic into a helper class.