### PR TITLE
DM-49374: Batch Gafaelfawr token creations

### DIFF
--- a/changelog.d/20250307_094752_rra_DM_49374.md
+++ b/changelog.d/20250307_094752_rra_DM_49374.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Batch Gafaelfawr token creations in groups of 10 instead of attempting to perform them all in parallel. Gafaelfawr has to serialize them on database transactions anyway, so running all token creations at once with a large flock causes problems with HTTP request timeouts.


### PR DESCRIPTION
Batch the creation of Gafaelfawr tokens during flock startup and only perform 10 at a time. This will still provide some parallel speed-up without causing a pile-up on the Gafaelfawr side waiting for database transactions, which in turn causes problems with HTTP timeouts on the mobu side.