### PR TITLE
DM-49526: Skip summary message if there are no flocks

### DIFF
--- a/changelog.d/20250317_162821_rra_DM_49526.md
+++ b/changelog.d/20250317_162821_rra_DM_49526.md
@@ -1,0 +1,3 @@
+### Bug fixes
+
+- Do not send a summary message to Slack if there are no flocks running.

--- a/src/mobu/status.py
+++ b/src/mobu/status.py
@@ -25,8 +25,15 @@ async def post_status() -> None:
     if not slack:
         return
 
+    # Get the flock summaries.
     summaries = process_context.manager.summarize_flocks()
     flock_count = len(summaries)
+
+    # Skip the status report if there are no flocks.
+    if not flock_count:
+        return
+
+    # Construct the status report.
     flock_plural = "flock" if flock_count == 1 else "flocks"
     text = (
         f"Currently running {flock_count} {flock_plural} against"
@@ -55,4 +62,5 @@ async def post_status() -> None:
         )
         text += line
 
+    # Post the result to Slack.
     await slack.post(SlackMessage(message=text))

--- a/tests/status_test.py
+++ b/tests/status_test.py
@@ -19,6 +19,13 @@ from mobu.status import post_status
 async def test_post_status(
     client: AsyncClient, slack: MockSlackWebhook, jupyter: MockJupyter
 ) -> None:
+    # If there are no flocks, no message should be posted.
+    with patch.object(FlockManager, "summarize_flocks") as mock:
+        mock.return_value = []
+        await post_status()
+        assert slack.messages == []
+
+    # Check with some actual flock data.
     with patch.object(FlockManager, "summarize_flocks") as mock:
         mock.return_value = [
             FlockSummary(


### PR DESCRIPTION
Stop sending summary messages if there are no flocks running, which will reduce the alert spam on T&S status channels where we currently don't use mobu. The original thought was that this would serve as a sort of heartbeat and would alert us if all flocks were stopped, but we mostly don't manually stop flocks and the annoyance of the empty messages probably exceeds the benefit as a heartbeat.