### PR TITLE
Fix broken link check test

### DIFF
--- a/docs/dev/idfdev.rst
+++ b/docs/dev/idfdev.rst
@@ -4,8 +4,7 @@ Testing against ``idfdev``
 
 You can run mobu locally while having all of the actual business run against services in ``idefdev`` (or any other environment).
 
-
-#. Install the `1Password CLI <https://developer.1password.com/docs/cli/>`__.
+#. Install the `1Password CLI <https://www.1password.dev/cli>`__.
 #. Generate a personal `idfdev gafaelfawr token <https://data-dev.lsst.cloud/settings/tokens/>`__ generated with an ``admin:token`` scope.
 #. Put this token in a ``data-dev.lsst.cloud personal token`` entry in your personal 1Password vault.
 #. Run mobu locally with something like this shell script:

--- a/docs/documenteer.toml
+++ b/docs/documenteer.toml
@@ -57,6 +57,9 @@ ignore = [
     '^https://data\.lsst\.cloud/mobu',
     '^https://github\.com/organizations/lsst-sqre/settings',
     '^https://github\.com/.*/issues/new$',
+    # StackOverflow no longer supports link checking (probably due to LLM bots)
+    '^https://stackoverflow.com/questions/14693701/',
+    '^https://stackoverflow.com/questions/31900244/',
 ]
 
 [sphinx.redirects]


### PR DESCRIPTION
Adjust the 1Password URL for a redirect, and stop probing StackOverflow links because StackOverflow is blocking bots.